### PR TITLE
Mousewheel stashscroll without ctrl option

### DIFF
--- a/src/main/shortcuts.ts
+++ b/src/main/shortcuts.ts
@@ -185,7 +185,10 @@ export function setupShortcuts () {
   })
 
   uIOhook.on('wheel', (e) => {
-    if (!e.ctrlKey || !PoeWindow.bounds || !PoeWindow.isActive || !config.get('stashScroll')) return
+    if (!PoeWindow.bounds || !PoeWindow.isActive) return
+    // stash scrolling modes: 0 = disabled, 1 = mousewheel with Ctrl, 2 = mousewheel without ctrl
+    if (config.get('stashScroll') == 0) return
+    if (config.get('stashScroll') == 1 && !e.ctrlKey) return
 
     if (!isGameScrolling(e)) {
       if (e.rotation > 0) {

--- a/src/web/settings/hotkeys.vue
+++ b/src/web/settings/hotkeys.vue
@@ -52,8 +52,9 @@
       <div class="flex">
         <div class="flex-1">{{ t('Stash tab scrolling') }}</div>
         <div class="flex">
-          <ui-radio v-model="config.stashScroll" :value="true" class="mr-4 font-fontin-regular">Ctrl + MouseWheel</ui-radio>
-          <ui-radio v-model="config.stashScroll" :value="false">{{ t('Disabled') }}</ui-radio>
+          <ui-radio v-model="config.stashScroll" :value="2" class="mr-4 font-fontin-regular">Ctrl + MouseWheel</ui-radio>
+          <ui-radio v-model="config.stashScroll" :value="1" class="mr-4 font-fontin-regular">MouseWheel</ui-radio>
+          <ui-radio v-model="config.stashScroll" :value="0">{{ t('Disabled') }}</ui-radio>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Related issue: https://github.com/SnosMe/awakened-poe-trade/issues/335

please check code, i needed to change the type of the "stashScroll" variable from bool to int