### PR TITLE
Added MacOS support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "animate.css": "^4.1.1",
     "apexcharts": "^3.23.1",
     "dot-prop": "6.x.x",
-    "electron-overlay-window": "2.0.x",
+    "electron-overlay-window": "hsource/electron-overlay-window#v2.0.1-macos.1",
     "electron-store": "7.0.x",
     "electron-updater": "^4.2.0",
     "fast-deep-equal": "3.1.x",

--- a/src/ipc/types.ts
+++ b/src/ipc/types.ts
@@ -102,7 +102,9 @@ export const defaultConfig: Config = {
     send: true
   }],
   clientLog: null,
-  useOsGlobalShortcut: true,
+  // We enable this everywhere except on Mac: shortcuts registered through
+  // `globalShortcuts` don't seem to work there
+  useOsGlobalShortcut: process.platform !== 'darwin',
   windowTitle: 'Path of Exile',
   logLevel: 'warn',
   showSeller: false,

--- a/src/main/tray.ts
+++ b/src/main/tray.ts
@@ -41,9 +41,13 @@ function leaguesMenuItem () {
 }
 
 export function createTray () {
-  tray = new Tray(
-    nativeImage.createFromPath(path.join(__static, process.platform === 'win32' ? 'icon.ico' : 'icon.png'))
-  )
+  let trayImage = nativeImage.createFromPath(path.join(__static, process.platform === 'win32' ? 'icon.ico' : 'icon.png'))
+  if (process.platform === 'darwin') {
+    // Mac image size needs to be smaller, or else it looks huge. Size
+    // guideline is from https://iconhandbook.co.uk/reference/chart/osx/
+    trayImage = trayImage.resize({ width: 22, height: 22 })
+  }
+  tray = new Tray(trayImage)
 
   ipcMain.on(LEAGUES_READY, (e, leagues_: League[]) => {
     leagues = leagues_

--- a/vue.config.js
+++ b/vue.config.js
@@ -16,6 +16,13 @@ module.exports = {
         },
         linux: {
           target: ['AppImage']
+        },
+        mac: {
+          // Disable code signing. While we could release with an official
+          // developer identity, we haven't set it up yet. Disabled based on
+          // instructions here:
+          // https://www.electron.build/code-signing#how-to-disable-code-signing-during-the-build-process-on-macos
+          identity: null
         }
       }
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3560,10 +3560,9 @@ electron-devtools-installer@^3.1.1:
     semver "^7.2.1"
     unzip-crx-3 "^0.2.0"
 
-electron-overlay-window@2.0.x:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/electron-overlay-window/-/electron-overlay-window-2.0.1.tgz#c549d5436c7a10ceb4884f5eabcf0901c1880aea"
-  integrity sha512-ULweUF7N4i6GFTO6sEA32U/iMJFAAcM33j8mScqDvRriWbW8CGKhYwu0AYOuZLhVmzg869KPnThJiI9e4FcdjA==
+electron-overlay-window@hsource/electron-overlay-window#v2.0.1-macos.1:
+  version "2.0.1-macos.1"
+  resolved "https://codeload.github.com/hsource/electron-overlay-window/tar.gz/fd8db2f768eee94127298947af5750990afa5b15"
   dependencies:
     node-gyp-build "4.x.x"
     throttle-debounce "3.x.x"
@@ -9629,9 +9628,9 @@ typescript@4.2.x:
   integrity sha512-qOcYwxaByStAWrBf4x0fibwZvMRG+r4cQoTjbPtUlrWjBHbmCAww1i448U0GJ+3cNNEtebDteo/cHOR3xJ4wEw==
 
 uiohook-napi@1.0.x:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/uiohook-napi/-/uiohook-napi-1.0.7.tgz#a9e870a164107d0240f67a247b612354e88067aa"
-  integrity sha512-CO8fVvK/YZm6vNvU86DozYX1X0g99zgY7cvzuGDHDgqW3dPNj+hpswW1ssrKgCUkdmrRoUhNDVpX/zUhk5ycnQ==
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/uiohook-napi/-/uiohook-napi-1.0.8.tgz#31cd346fdbc7d073c51f14b98c965f14643eb158"
+  integrity sha512-kIydr9nz4CBkTh7t92L4xT9xrHBaGbSNAd3ZZUnBKvOcQvulW6XuUqFzmvHDIC+EkIjslADsmCgMPucKZQtMRw==
   dependencies:
     node-gyp-build "4.x.x"
 


### PR DESCRIPTION
## Motivation

I've been playing POE on Mac. Trading sucks as usual. I heard Awakened POE Trade was the best trade tool around, and it didn't seem too hard to port!

## Fixes

1. Upgrade uiohook-napi and electron-overlay-window for Mac support
   - electron-overlay-window update is pending [Added MacOS support #17](https://github.com/SnosMe/electron-overlay-window/pull/17). I'll update the package.json to refer to the new package once that's pulled/updated
2. Tweaked config a bit so that the default config works on Mac
   - Set `useOsGlobalShortcut: false` by default for Mac. For unknown reasons, the `globalShortcuts` hooks don't seem to ever get triggered on Mac
   - Have a smaller tray image
   - Disable code signing, mostly because I'm too lazy to set it up and it doesn't matter that much for Mac

## Testing

Tested with the game. It works pretty well!

https://user-images.githubusercontent.com/2937410/119623610-33c5c600-bdbd-11eb-92c7-f88a67acf900.mp4