### PR TITLE
Improve overlay for gambling in expedition league

### DIFF
--- a/src/web/price-check/unidentified-resolver/UnidentifiedResolver.vue
+++ b/src/web/price-check/unidentified-resolver/UnidentifiedResolver.vue
@@ -1,14 +1,20 @@
 <template>
   <div v-if="show" class="layout-column">
     <div class="m-4 py-1 px-2 bg-gray-900 rounded">
-      {{ t('You are trying to price check unidentified Unique item with base type "{0}". Which one?', [baseType]) }}
+      {{ t('You are trying to price check unidentified {0} item with base type "{1}". It possibly can be one of uniques:', [rarity, baseType]) }}
     </div>
     <div class="overflow-auto pb-4 px-4">
       <div class="flex flex-wrap -m-1">
-        <div v-for="item in identifiedVariants" :key="item.name" class="p-1 flex w-1/2">
-          <button @click="select(item.refName)" class="bg-gray-700 rounded flex items-center p-2 w-full">
-            <img :src="item.icon" class="w-12" />
-            <div class="pl-3 leading-tight">{{ item.name }}</div>
+        <div v-for="unique in identifiedVariants" :key="unique.item.name" class="p-1 flex w-full">
+          <button @click="select(unique.item)" class="bg-gray-700 rounded flex items-center p-2 w-full">
+            <img :src="unique.item.icon" class="w-12" />
+            <div class="flex-1 pl-3 text-left leading-tight">{{ unique.renderName }}</div>
+            <item-quick-price
+              :min="unique.price.val"
+              :max="unique.price.val"
+              :hideItem="true"
+              :currency="unique.price.curr === 'e' ? 'exa' : 'chaos'"
+            />
           </button>
         </div>
       </div>
@@ -21,8 +27,14 @@ import { defineComponent, PropType, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { UNIQUES_LIST, TRANSLATED_ITEM_NAME_BY_REF } from '@/assets/data'
 import { ItemRarity, ParsedItem } from '@/parser'
+import ItemQuickPrice from '@/web/ui/ItemQuickPrice.vue'
+import { findByDetailsId, autoCurrency } from '../../background/Prices'
+import { getDetailsId } from '../trends/getDetailsId'
 
 export default defineComponent({
+  components: {
+    ItemQuickPrice
+  },
   emits: ['identify'],
   props: {
     item: {
@@ -35,23 +47,26 @@ export default defineComponent({
       const name = props.item!.name
       const possible = UNIQUES_LIST
         .filter(unique => unique.basetype === name)
-        .map(unique => ({
-          refName: unique.name,
-          icon: unique.icon,
-          name: TRANSLATED_ITEM_NAME_BY_REF.get(unique.name) || unique.name
-        }))
+        .map(unique => {
+          const item = getUniqueItem(props.item!, unique.name, unique.icon)
+          const price = autoCurrency(findByDetailsId(getDetailsId(item)!)!.receive.chaosValue, 'c')
+          return {
+            renderName: TRANSLATED_ITEM_NAME_BY_REF.get(item.name) || item.name,
+            item,
+            price
+          }
+        })
 
-      if (possible.length === 1) {
-        select(possible[0].refName)
+      if (possible.length === 1 && props.item!.rarity === ItemRarity.Unique) {
+        select(possible[0].item)
       }
-
       return possible
     })
 
     const show = computed(() => {
       if (!props.item) return false
 
-      return props.item.rarity === ItemRarity.Unique &&
+      return (props.item.rarity === ItemRarity.Unique || props.item.rarity === ItemRarity.Normal) &&
         props.item.isUnidentified &&
         props.item.baseType == null
     })
@@ -61,19 +76,29 @@ export default defineComponent({
         props.item!.name
     })
 
-    function select (name: string) {
+    const rarity = computed(() => {
+      return props.item!.rarity
+    })
+
+    function select (item: ParsedItem) {
+      ctx.emit('identify', item)
+    }
+
+    function getUniqueItem (base: ParsedItem, name: string, icon: string) {
       if ([
         'Agnerod East', 'Agnerod North', 'Agnerod South', 'Agnerod West'
       ].includes(name)) {
         name = 'Agnerod'
       }
 
-      const newItem: ParsedItem = {
-        ...props.item!,
+      return {
+        ...base,
         name: name,
-        baseType: props.item!.name
+        baseType: base.name,
+        isUnidentified: false,
+        rarity: ItemRarity.Unique,
+        icon
       }
-      ctx.emit('identify', newItem)
     }
 
     const { t } = useI18n()
@@ -82,6 +107,7 @@ export default defineComponent({
       t,
       identifiedVariants,
       show,
+      rarity,
       baseType,
       select
     }
@@ -92,7 +118,7 @@ export default defineComponent({
 <i18n>
 {
   "ru": {
-    "You are trying to price check unidentified Unique item with base type \"{0}\". Which one?": "Вы пытаетесь сделать прайс-чек неопознанного Уникального предмета с базой \"{0}\". Какого именно?"
+    "You are trying to price check unidentified {0} item with base type \"{1}\". It possibly can be one of uniques:": "Вы пытаетесь сделать прайс-чек неопознанного {0} предмета с базой \"{1}\". Это может быть один из уникальных предметов:"
   }
 }
 </i18n>

--- a/src/web/ui/ItemQuickPrice.vue
+++ b/src/web/ui/ItemQuickPrice.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="flex items-center justify-center">
-    <slot name="item">
+    <slot v-if="!hideItem" name="item">
       <div class="w-8 h-8 flex items-center justify-center">
         <img :src="itemImg" class="max-w-full max-h-full overflow-hidden">
       </div>
@@ -50,6 +50,10 @@ export default defineComponent({
     itemImg: {
       type: String,
       default: require('@/assets/images/wisdom.png').default
+    },
+    hideItem: {
+      type: Boolean,
+      default: false
     }
   },
   setup (props) {


### PR DESCRIPTION
I've got an idea of displaying list of possible unique outcomes for gambling.
There is PR about this already https://github.com/SnosMe/awakened-poe-trade/pull/424, but I think my version is more usable and requires less clicks
https://i.imgur.com/AuASsCZ.png