### PR TITLE
Added new and up-to-date community wiki link

### DIFF
--- a/src/web/other-services/wiki.ts
+++ b/src/web/other-services/wiki.ts
@@ -4,7 +4,7 @@ import { Config } from '@/web/Config'
 import { TRANSLATED_ITEM_NAME_BY_REF } from '@/assets/data'
 
 const ENDPOINT_BY_LANG = {
-  en: 'pathofexile.gamepedia.com',
+  en: 'www.poewiki.net/wiki/',
   ru: 'pathofexile-ru.gamepedia.com'
 }
 


### PR DESCRIPTION
As the community has moved away from the Fandom-hosted wiki, and the community efforts have merged to stand up a new de-facto wiki project (which was announced as live earlier today [here](https://www.reddit.com/r/pathofexile/comments/pc04t4/project_path_of_exile_wiki_week_3_update/) we propose changing the default EN wiki URL to the following one - `www.poewiki.net/wiki/` which in turn employs no ads, no user tracking or fingerprinting and has received nothing but positive feedback as the replacement for the old and outdated Fandom site.

We sincerely hope you consider merging this PR.

On behalf of the Project PoE Wiki team.