### PR TITLE
Overlay stash-search names and hotkeys

### DIFF
--- a/ipc/types.ts
+++ b/ipc/types.ts
@@ -185,10 +185,10 @@ export const defaultConfig = (): Config => ({
         y: 46
       },
       entries: [
-        { id: 1, text: '"Pack Size: +3"' },
-        { id: 2, text: 'Reflect' },
-        { id: 3, text: '"Cannot Leech Life"' },
-        { id: 4, text: '"Cannot Leech Mana"' }
+        { id: 1, name: '', text: '"Pack Size: +3"' },
+        { id: 2, name: '', text: 'Reflect' },
+        { id: 3, name: '', text: '"Cannot Leech Life"' },
+        { id: 4, name: '', text: '"Cannot Leech Mana"' }
       ]
     } as widget.StashSearchWidget,
     {
@@ -204,12 +204,12 @@ export const defaultConfig = (): Config => ({
         y: 56
       },
       entries: [
-        { id: 1, text: 'Currency' },
-        { id: 2, text: '"Divination Card"' },
-        { id: 3, text: 'Fossil' },
-        { id: 4, text: '"Map Tier"' },
-        { id: 5, text: '"Map Device" "Rarity: Normal"' },
-        { id: 6, text: 'Tane Laboratory' }
+        { id: 1, name: '', text: 'Currency' },
+        { id: 2, name: '', text: '"Divination Card"' },
+        { id: 3, name: '', text: 'Fossil' },
+        { id: 4, name: '', text: '"Map Tier"' },
+        { id: 5, name: '', text: '"Map Device" "Rarity: Normal"' },
+        { id: 6, name: '', text: 'Tane Laboratory' }
       ]
     } as widget.StashSearchWidget,
     {

--- a/ipc/types.ts
+++ b/ipc/types.ts
@@ -185,10 +185,10 @@ export const defaultConfig = (): Config => ({
         y: 46
       },
       entries: [
-        { id: 1, name: '', text: '"Pack Size: +3"' },
-        { id: 2, name: '', text: 'Reflect' },
-        { id: 3, name: '', text: '"Cannot Leech Life"' },
-        { id: 4, name: '', text: '"Cannot Leech Mana"' }
+        { id: 1, name: '', text: '"Pack Size: +3"', hotkey: null },
+        { id: 2, name: '', text: 'Reflect', hotkey: null },
+        { id: 3, name: '', text: '"Cannot Leech Life"', hotkey: null },
+        { id: 4, name: '', text: '"Cannot Leech Mana"', hotkey: null }
       ]
     } as widget.StashSearchWidget,
     {
@@ -204,12 +204,12 @@ export const defaultConfig = (): Config => ({
         y: 56
       },
       entries: [
-        { id: 1, name: '', text: 'Currency' },
-        { id: 2, name: '', text: '"Divination Card"' },
-        { id: 3, name: '', text: 'Fossil' },
-        { id: 4, name: '', text: '"Map Tier"' },
-        { id: 5, name: '', text: '"Map Device" "Rarity: Normal"' },
-        { id: 6, name: '', text: 'Tane Laboratory' }
+        { id: 1, name: '', text: 'Currency', hotkey: null },
+        { id: 2, name: '', text: '"Divination Card"', hotkey: null },
+        { id: 3, name: '', text: 'Fossil', hotkey: null },
+        { id: 4, name: '', text: '"Map Tier"', hotkey: null },
+        { id: 5, name: '', text: '"Map Device" "Rarity: Normal"', hotkey: null },
+        { id: 6, name: '', text: 'Tane Laboratory', hotkey: null }
       ]
     } as widget.StashSearchWidget,
     {

--- a/ipc/widgets.ts
+++ b/ipc/widgets.ts
@@ -63,7 +63,7 @@ export interface StashSearchWidget extends Widget {
   anchor: Anchor
   entries: Array<{
     id: number
-    name: string
+    name: string | null
     text: string
     hotkey: string | null
   }>

--- a/ipc/widgets.ts
+++ b/ipc/widgets.ts
@@ -63,6 +63,7 @@ export interface StashSearchWidget extends Widget {
   anchor: Anchor
   entries: Array<{
     id: number
+    name: string
     text: string
   }>
 }

--- a/ipc/widgets.ts
+++ b/ipc/widgets.ts
@@ -65,6 +65,7 @@ export interface StashSearchWidget extends Widget {
     id: number
     name: string
     text: string
+    hotkey: string | null
   }>
 }
 

--- a/ipc/widgets.ts
+++ b/ipc/widgets.ts
@@ -63,7 +63,7 @@ export interface StashSearchWidget extends Widget {
   anchor: Anchor
   entries: Array<{
     id: number
-    name: string | null
+    name: string
     text: string
     hotkey: string | null
   }>

--- a/main/src/shortcuts.ts
+++ b/main/src/shortcuts.ts
@@ -9,10 +9,10 @@ import { PoeWindow } from './PoeWindow'
 import { logger } from './logger'
 import { toggleOverlayState, assertOverlayActive, assertPoEActive, overlayOnEvent, overlaySendEvent } from './overlay-window'
 import * as ipc from '../../ipc/ipc-event'
+import { StashSearchWidget } from '../../ipc/widgets'
 import { typeInChat } from './game-chat'
 import { gameConfig } from './game-config'
 import { restoreClipboard } from './clipboard-saver'
-import { StashSearchWidget } from '../../ipc/widgets'
 
 export const UiohookToName = Object.fromEntries(Object.entries(UiohookKey).map(([k, v]) => ([v, k])))
 
@@ -48,6 +48,7 @@ export interface ShortcutAction {
 
 function shortcutsFromConfig () {
   let actions: ShortcutAction[] = []
+
   const priceCheckCfg = priceCheckConfig()
   if (priceCheckCfg.hotkey) {
     actions.push({
@@ -108,8 +109,8 @@ function shortcutsFromConfig () {
     })
   }
   for (const widget of config.get('widgets')) {
-    if (widget.wmType == "stash-search") {
-      const stashSearch = widget as StashSearchWidget;
+    if (widget.wmType === 'stash-search') {
+      const stashSearch = widget as StashSearchWidget
       for (const entry of stashSearch.entries) {
         if (entry.hotkey) {
           actions.push({

--- a/renderer/src/web/overlay/WidgetStashSearch.vue
+++ b/renderer/src/web/overlay/WidgetStashSearch.vue
@@ -22,7 +22,7 @@
                 <input v-model="entry.name"
                   :placeholder="t('entry name')"
                   class="absolute top-0 w-full leading-4 text-gray-100 py-2 px-1"
-                  :class="(entry?.name?.length > 50) ? 'bg-red-800' : 'bg-gray-700'">
+                  :class="(entry.name?.length > 50) ? 'bg-red-800' : 'bg-gray-700'">
               </div>
               <div class="relative flex-1" style="min-width: 15rem;">
                 <div class="leading-4 py-2 px-2 whitespace-nowrap">{{ entry.text }}{{ '\u2009' }}</div>
@@ -30,6 +30,10 @@
                   :placeholder="t('search text')"
                   class="absolute top-0 w-full leading-4 text-gray-100 py-2 px-1"
                   :class="(entry.text.length > 50) ? 'bg-red-800' : 'bg-gray-700'">
+              </div>
+              <div class="relative flex ml-2 text-gray-100" style="min-width: 5rem;">
+                <label class="flex mr-1">Key:</label>
+                <hotkey-input v-model="entry.hotkey" class="w-24" />
               </div>
               <button class="p-2 leading-none" @click="removeEntry(entry.id)">
                 <i class="fas fa-times text-gray-600"></i>
@@ -42,7 +46,10 @@
       </template>
       <div v-else class="flex flex-col gap-y-1 mt-2">
         <button v-for="entry in config.entries" :key="entry.id" @click="stashSearch(entry.text)"
-          class="leading-4 text-gray-100 p-2 rounded text-left bg-gray-800 whitespace-nowrap">{{!!entry.name ? entry.name + ': ' : ''}}{{ entry.text }}</button>
+          class="leading-4 text-gray-100 p-2 rounded text-left bg-gray-800 whitespace-nowrap">
+            {{!!entry.name ? entry.name : entry.text}}
+            <span class="text-gray-500">{{!!entry.hotkey ? `(${entry.hotkey})` : ''}}</span>
+        </button>
       </div>
     </div>
   </widget>
@@ -55,9 +62,10 @@ import Widget from './Widget.vue'
 import DndContainer from 'vuedraggable'
 import { MainProcess } from '@/web/background/IPC'
 import { WidgetManager, StashSearchWidget } from './interfaces'
+import HotkeyInput from '../settings/HotkeyInput.vue'
 
 export default defineComponent({
-  components: { Widget, DndContainer },
+  components: { Widget, DndContainer, HotkeyInput },
   props: {
     config: {
       type: Object as PropType<StashSearchWidget>,
@@ -75,7 +83,7 @@ export default defineComponent({
         y: (Math.random() * (40 - 20) + 20)
       }
       props.config.entries = [{
-        id: 1, name: 'Currency', text: 'Currency'
+        id: 1, name: 'Currency', text: 'Currency', hotkey: null
       }]
       wm.show(props.config.wmId)
     }
@@ -91,7 +99,8 @@ export default defineComponent({
         props.config.entries.push({
           id: Math.max(0, ...props.config.entries.map(_ => _.id)) + 1,
           name: '',
-          text: ''
+          text: '',
+          hotkey: null
         })
       },
       stashSearch (text: string) {
@@ -110,7 +119,8 @@ export default defineComponent({
   "ru": {
     "entry name": "имя записи",
     "widget title": "заголовок виджета",
-    "search text": "текст поиска"
+    "search text": "текст поиска",
+    "hotkey": "Быстрые клавиши"
   }
 }
 </i18n>

--- a/renderer/src/web/overlay/WidgetStashSearch.vue
+++ b/renderer/src/web/overlay/WidgetStashSearch.vue
@@ -33,7 +33,8 @@
               </div>
               <div class="relative flex ml-2 text-gray-100" style="min-width: 5rem;">
                 <label class="flex mr-1">Key:</label>
-                <hotkey-input v-model="entry.hotkey" class="w-24" />
+                <hotkey-input v-model="entry.hotkey"
+                  v-on:update:model-value="handleKeyChanged" class="w-24"/>
               </div>
               <button class="p-2 leading-none" @click="removeEntry(entry.id)">
                 <i class="fas fa-times text-gray-600"></i>
@@ -63,6 +64,7 @@ import DndContainer from 'vuedraggable'
 import { MainProcess } from '@/web/background/IPC'
 import { WidgetManager, StashSearchWidget } from './interfaces'
 import HotkeyInput from '../settings/HotkeyInput.vue'
+import { saveConfig } from '../Config'
 
 export default defineComponent({
   components: { Widget, DndContainer, HotkeyInput },
@@ -102,6 +104,15 @@ export default defineComponent({
           text: '',
           hotkey: null
         })
+      },
+      handleKeyChanged () {
+        // This manual save is necessary because of update order.
+        // Normally config save happens automatically by OverlayWindow when it goes from
+        // Overlay active to PoE active. But the new hotkey bindings are loaded before
+        // OverlayWindow has the settings saved.
+        // This means is always a delay of one "opening" between changing hotkeys and
+        // useable hotkeys.
+        saveConfig()
       },
       stashSearch (text: string) {
         MainProcess.sendEvent({

--- a/renderer/src/web/overlay/WidgetStashSearch.vue
+++ b/renderer/src/web/overlay/WidgetStashSearch.vue
@@ -17,6 +17,13 @@
               <button class="p-2 leading-none cursor-move" data-qa="drag-handle">
                 <i class="fas fa-grip-vertical text-gray-400"></i>
               </button>
+              <div class="relative flex-1 mr-2" style="min-width: 15rem;">
+                <div class="leading-4 py-2 px-2 whitespace-nowrap">{{ entry.name }}{{ '\u2009' }}</div>
+                <input v-model="entry.name"
+                  :placeholder="t('entry name')"
+                  class="absolute top-0 w-full leading-4 text-gray-100 py-2 px-1"
+                  :class="(entry?.name?.length > 50) ? 'bg-red-800' : 'bg-gray-700'">
+              </div>
               <div class="relative flex-1" style="min-width: 15rem;">
                 <div class="leading-4 py-2 px-2 whitespace-nowrap">{{ entry.text }}{{ '\u2009' }}</div>
                 <input v-model="entry.text"
@@ -35,7 +42,7 @@
       </template>
       <div v-else class="flex flex-col gap-y-1 mt-2">
         <button v-for="entry in config.entries" :key="entry.id" @click="stashSearch(entry.text)"
-          class="leading-4 text-gray-100 p-2 rounded text-left bg-gray-800 whitespace-nowrap">{{ entry.text }}</button>
+          class="leading-4 text-gray-100 p-2 rounded text-left bg-gray-800 whitespace-nowrap">{{!!entry.name ? entry.name + ': ' : ''}}{{ entry.text }}</button>
       </div>
     </div>
   </widget>
@@ -68,7 +75,7 @@ export default defineComponent({
         y: (Math.random() * (40 - 20) + 20)
       }
       props.config.entries = [{
-        id: 1, text: 'Currency'
+        id: 1, name: 'Currency', text: 'Currency'
       }]
       wm.show(props.config.wmId)
     }
@@ -83,6 +90,7 @@ export default defineComponent({
       addEntry () {
         props.config.entries.push({
           id: Math.max(0, ...props.config.entries.map(_ => _.id)) + 1,
+          name: '',
           text: ''
         })
       },
@@ -100,6 +108,7 @@ export default defineComponent({
 <i18n>
 {
   "ru": {
+    "entry name": "имя записи",
     "widget title": "заголовок виджета",
     "search text": "текст поиска"
   }

--- a/renderer/src/web/overlay/WidgetStashSearch.vue
+++ b/renderer/src/web/overlay/WidgetStashSearch.vue
@@ -5,8 +5,9 @@
       <div class="flex flex-col gap-y-1 mt-2">
         <button v-for="entry in config.entries" :key="entry.id" @click="stashSearch(entry.text)"
           class="leading-4 text-gray-100 p-2 rounded text-left bg-gray-800 whitespace-nowrap">
-            {{!!entry.name ? entry.name : entry.text}}
-            <span class="text-gray-500">{{!!entry.hotkey ? `(${entry.hotkey})` : ''}}</span>
+            {{ entry.name || entry.text }}
+            <span v-if="entry.hotkey"
+              class="text-center inline-block text-black bg-gray-400 rounded px-1">{{ entry.hotkey }}</span>
         </button>
       </div>
     </div>

--- a/renderer/src/web/overlay/WidgetStashSearch.vue
+++ b/renderer/src/web/overlay/WidgetStashSearch.vue
@@ -29,12 +29,13 @@
                 <input v-model="entry.text"
                   :placeholder="t('search text')"
                   class="absolute top-0 w-full leading-4 text-gray-100 py-2 px-1"
-                  :class="(entry.text.length > 50) ? 'bg-red-800' : 'bg-gray-700'">
+                  :class="(entry.text.length > 50) ? 'bg-red-800' : 'bg-gray-700'"
+                  @blur="handleDataChanged">
               </div>
               <div class="relative flex ml-2 text-gray-100" style="min-width: 5rem;">
                 <label class="flex mr-1">Key:</label>
                 <hotkey-input v-model="entry.hotkey"
-                  v-on:update:model-value="handleKeyChanged" class="w-24"/>
+                  v-on:update:model-value="handleDataChanged" class="w-24"/>
               </div>
               <button class="p-2 leading-none" @click="removeEntry(entry.id)">
                 <i class="fas fa-times text-gray-600"></i>
@@ -105,7 +106,7 @@ export default defineComponent({
           hotkey: null
         })
       },
-      handleKeyChanged () {
+      handleDataChanged () {
         // This manual save is necessary because of update order.
         // Normally config save happens automatically by OverlayWindow when it goes from
         // Overlay active to PoE active. But the new hotkey bindings are loaded before


### PR DESCRIPTION
Adds optional names and hotkeys to stash searches. 

The names are useful to hide complex regex searches behind a more understandable name (#413). They have no effect on what the search. If you do not supply a name, it will instead display the search text.
The optional hotkey just calls searchStash directly without having to open the overlay.

All the changes in types/config are optional "string | null" types. I decided to not add a config migration and a new config. If you think it would be better to have this behind a new config version I can add that.
For the russian translation you will have to check for correctness, I only used google translate for the names.

Otherwise I am open to feedback.

Screenshots for the ui:
Editing
![stash-searches01](https://user-images.githubusercontent.com/855322/162594486-bf4d721b-68fe-4f93-8fba-fd3c920ad58a.png)
Display
![stash-searches02](https://user-images.githubusercontent.com/855322/162594483-47fce3d8-8be5-4855-8ea3-d94697cf8de8.png)

