### PR TITLE
Fixes invalid first line detector for TH language.

### DIFF
--- a/main/src/poll-clipboard.ts
+++ b/main/src/poll-clipboard.ts
@@ -90,7 +90,7 @@ export const LANGUAGE_DETECTOR = [{
   firstLine: 'Clase de objeto: '
 }, {
   lang: 'th',
-  firstLine: 'คลาสของไอเทม: '
+  firstLine: 'ชนิดไอเทม: '
 }, {
   lang: 'ko',
   firstLine: '아이템 종류: '


### PR DESCRIPTION
The price check feature doesn't work for Thai language for quite some time, not sure when GGG updated the text for the item clipboard for Thai language.

it's currently showing like this

```
ชนิดไอเทม: คทา
ความหายาก: ยูนิค
Earendel's Embrace
Grinning Fetish
--------
คทา
ความเสียหายกายภาพ: 24-36
โอกาสคริติคอล: 6.00%
จำนวนครั้งการโจมตีต่อวินาที: 1.50
ระยะของอาวุธ: 11
--------
เงื่อนไข:
เลเวล: 58
Str: 130
Int: 62
--------
รู: B-R 
--------
เลเวลไอเทม: 52
--------
เพิ่มความเสียหาย ธาตุ 18% (implicit)
--------
ค่าคุณสมบัติทั้งหมด +20
มิเนียน สร้างความเสียหาย เพิ่มขึ้น 35%
โครงกระดูกที่ถูกอัญเชิญ สร้างสถานะ อาบขี้เถ้า ต่อศัตรูเมื่อปะทะ
โครงกระดูกที่ถูกอัญเชิญ ได้รับความเสียหาย 28.3% ของ พลังชีวิตสูงสุด ของพวกมัน เป็นความเสียหาย ไฟ ต่อวินาที
โครงกระดูกที่ถูกอัญเชิญ มี Avatar of Fire
--------
ฝูง​มนุษย์​เหนื่อยล้า​มหาศาล
จะ​แปลงกาย​ให้​เป็น​ไฟ​อัน​แสนกว้าง
อัน​ร้อน​แรง​ที่​ท่วม​ผู้​อยู่​รอด
บาง​คน​ก็​ขึ้น บ้าง​ก็​ลง มี​แต่​ความ​ทุกข์​ทน
```

So the solution should be easy as just changing the expected text from `คลาสของไอเทม` to `ชนิดไอเทม`.