### PR TITLE
feat: Adds offline trades config toggle

### DIFF
--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -313,6 +313,7 @@
     "fill_rolls": "Fill stat values",
     "fill_roll_exact": "Exact value",
     "cursor_pos": "Show memorized cursor position",
+    "show_offline": "Automatically filter for both online & offline trades",
     "extra_delay": "Extra time to prevent spurious Rate limiting",
     "warn_expensive": "Settings below are a compromise between increasing load on PoE website and convenient price checking / more accurate search.",
     "accurate_collapsed": "Show indication on collapsed listings",

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -193,6 +193,7 @@ export const defaultConfig = (): Config => ({
       showSeller: false,
       searchStatRange: 10,
       showCursor: true,
+      showOffline: false,
       requestPricePrediction: false,
       rememberCurrency: false
     } as widget.PriceCheckWidget,

--- a/renderer/src/web/overlay/widgets.ts
+++ b/renderer/src/web/overlay/widgets.ts
@@ -43,6 +43,7 @@ export interface PriceCheckWidget extends Widget {
   requestPricePrediction: boolean
   builtinBrowser: boolean
   rememberCurrency: boolean
+  showOffline: boolean
 }
 
 export interface ItemCheckWidget extends Widget {

--- a/renderer/src/web/price-check/CheckedItem.vue
+++ b/renderer/src/web/price-check/CheckedItem.vue
@@ -116,7 +116,8 @@ export default defineComponent({
         currency: widget.value.rememberCurrency || (prevItem &&
           item.info.namespace === prevItem.info.namespace &&
           item.info.refName === prevItem.info.refName
-        ) ? prevCurrency : undefined
+        ) ? prevCurrency : undefined,
+        offline: widget.value.showOffline
       })
 
       if ((!props.advancedCheck && !widget.value.smartInitialSearch) ||

--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -14,6 +14,7 @@ interface CreateOptions {
   activateStockFilter: boolean
   exact: boolean
   useEn: boolean
+  offline: boolean
 }
 
 export function createFilters (
@@ -23,7 +24,7 @@ export function createFilters (
   const filters: ItemFilters = {
     searchExact: {},
     trade: {
-      offline: false,
+      offline: opts.offline,
       onlineInLeague: false,
       listed: undefined,
       currency: opts.currency,

--- a/renderer/src/web/price-check/filters/create-presets.ts
+++ b/renderer/src/web/price-check/filters/create-presets.ts
@@ -15,6 +15,7 @@ export function createPresets (
     activateStockFilter: boolean
     searchStatRange: number
     useEn: boolean
+    offline: boolean
   }
 ): { presets: FilterPreset[], active: string } {
   if (item.info.refName === 'Expedition Logbook') {

--- a/renderer/src/web/settings/price-check.vue
+++ b/renderer/src/web/settings/price-check.vue
@@ -62,6 +62,8 @@
       <ui-checkbox v-model="builtinBrowser">{{ t(':enable_browser') }}</ui-checkbox>
       <div v-if="builtinBrowser" class="mt-1">{{ t(':builtin_browser_warning') }}</div>
     </div>
+    <ui-checkbox class="mb-4"
+      v-model="showOffline">{{ t(':show_offline') }}</ui-checkbox>
     <div class="border-2 rounded border-gray-700 mb-2">
       <div class="bg-gray-700 p-2 mb-2">{{ t(':warn_expensive') }}</div>
       <ui-checkbox class="mb-4 mx-2" :values="['app', 'api']"
@@ -121,6 +123,7 @@ export default defineComponent({
       showSeller: configModelValue(() => configWidget.value, 'showSeller'),
       activateStockFilter: configModelValue(() => configWidget.value, 'activateStockFilter'),
       showCursor: configModelValue(() => configWidget.value, 'showCursor'),
+      showOffline: configModelValue(() => configWidget.value, 'showOffline'),
       builtinBrowser: configModelValue(() => configWidget.value, 'builtinBrowser'),
       requestPricePrediction: configModelValue(() => configWidget.value, 'requestPricePrediction'),
       collapseListings: configModelValue(() => configWidget.value, 'collapseListings'),


### PR DESCRIPTION
- Adds offline trades config toggle
- Defaults the new config option to false (for parity)
- Passes the config option into the initial search
  - The option may be overridden via the OnlineFilter, as normal.

Fixes:
- https://github.com/SnosMe/awakened-poe-trade/issues/953
- https://github.com/SnosMe/awakened-poe-trade/issues/807

New Setting: 
![image](https://github.com/SnosMe/awakened-poe-trade/assets/39996391/c11188f1-e8d1-4f82-b3e6-e00b3ea567cc)
_Happy to rename the toggle if there's a standard naming convention_
