### PR TITLE
Sets default paths on Linux

### DIFF
--- a/main/src/host-files/GameConfig.ts
+++ b/main/src/host-files/GameConfig.ts
@@ -9,33 +9,12 @@ import type { ServerEvents } from '../server'
 
 const POSSIBLE_PATH =
   (process.platform === 'win32') ? [
-    path.join(app.getPath('documents'), 'My Games', 'Path of Exile', 'production_Config.ini')
+    path.join(app.getPath('documents'), 'My Games\\Path of Exile\\production_Config.ini')
   ] : (process.platform === 'linux') ? [
-    path.join(
-      app.getPath("documents"),
-      "My Games",
-      "Path of Exile",
-      "production_Config.ini"
-    ),
-    path.join(
-      app.getPath("home"),
-      ".local",
-      "share",
-      "Steam",
-      "steamapps",
-      "compatdata",
-      "238960",
-      "pfx",
-      "drive_c",
-      "users",
-      "steamuser",
-      "Documents",
-      "My Games",
-      "Path of Exile",
-      "production_Config.ini"
-    ),
+    path.join(app.getPath('documents'), 'My Games/Path of Exile/production_Config.ini'),
+    path.join(app.getPath('home'), '.local/share/Steam/steamapps/compatdata/238960/pfx/drive_c/users/steamuser/Documents/My Games/Path of Exile/production_Config.ini')
   ] : (process.platform === 'darwin') ? [
-    path.join(app.getPath('appData'), 'Path of Exile', 'Preferences', 'production_Config.ini')
+    path.join(app.getPath('appData'), 'Path of Exile/Preferences/production_Config.ini')
   ] : []
 
 export class GameConfig {

--- a/main/src/host-files/GameConfig.ts
+++ b/main/src/host-files/GameConfig.ts
@@ -11,7 +11,29 @@ const POSSIBLE_PATH =
   (process.platform === 'win32') ? [
     path.join(app.getPath('documents'), 'My Games', 'Path of Exile', 'production_Config.ini')
   ] : (process.platform === 'linux') ? [
-    // TODO
+    path.join(
+      app.getPath("documents"),
+      "My Games",
+      "Path of Exile",
+      "production_Config.ini"
+    ),
+    path.join(
+      app.getPath("home"),
+      ".local",
+      "share",
+      "Steam",
+      "steamapps",
+      "compatdata",
+      "238960",
+      "pfx",
+      "drive_c",
+      "users",
+      "steamuser",
+      "Documents",
+      "My Games",
+      "Path of Exile",
+      "production_Config.ini"
+    ),
   ] : (process.platform === 'darwin') ? [
     path.join(app.getPath('appData'), 'Path of Exile', 'Preferences', 'production_Config.ini')
   ] : []

--- a/main/src/host-files/GameLogWatcher.ts
+++ b/main/src/host-files/GameLogWatcher.ts
@@ -1,4 +1,5 @@
 import { promises as fs, watchFile, unwatchFile } from 'fs'
+import path from 'path'
 import { app } from 'electron'
 import { guessFileLocation } from './utils'
 import { ServerEvents } from '../server'
@@ -9,7 +10,27 @@ const POSSIBLE_PATH =
     'C:\\Program Files (x86)\\Grinding Gear Games\\Path of Exile\\logs\\Client.txt',
     'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Path of Exile\\logs\\Client.txt'
   ] : (process.platform === 'linux') ? [
-    // TODO
+    path.join(
+      app.getPath('home'),
+      '.wine',
+      'drive_c',
+      'Program Files (x86)',
+      'Grinding Gear Games',
+      'Path of Exile',
+      'logs',
+      'Client.txt'
+    ),
+    path.join(
+      app.getPath('home'),
+      '.local',
+      'share',
+      'Steam',
+      'steamapps',
+      'common',
+      'Path of Exile',
+      'logs',
+      'Client.txt'
+    ),
   ] : (process.platform === 'darwin') ? [
     `${app.getPath('home')}/Library/Caches/com.GGG.PathOfExile/Logs/Client.txt`
   ] : []

--- a/main/src/host-files/GameLogWatcher.ts
+++ b/main/src/host-files/GameLogWatcher.ts
@@ -10,29 +10,10 @@ const POSSIBLE_PATH =
     'C:\\Program Files (x86)\\Grinding Gear Games\\Path of Exile\\logs\\Client.txt',
     'C:\\Program Files (x86)\\Steam\\steamapps\\common\\Path of Exile\\logs\\Client.txt'
   ] : (process.platform === 'linux') ? [
-    path.join(
-      app.getPath('home'),
-      '.wine',
-      'drive_c',
-      'Program Files (x86)',
-      'Grinding Gear Games',
-      'Path of Exile',
-      'logs',
-      'Client.txt'
-    ),
-    path.join(
-      app.getPath('home'),
-      '.local',
-      'share',
-      'Steam',
-      'steamapps',
-      'common',
-      'Path of Exile',
-      'logs',
-      'Client.txt'
-    ),
+    path.join(app.getPath('home'), '.wine/drive_c/Program Files (x86)/Grinding Gear Games/Path of Exile/logs/Client.txt'),
+    path.join(app.getPath('home'), '.local/share/Steam/steamapps/common/Path of Exile/logs/Client.txt')
   ] : (process.platform === 'darwin') ? [
-    `${app.getPath('home')}/Library/Caches/com.GGG.PathOfExile/Logs/Client.txt`
+    path.join(app.getPath('home'), 'Library/Caches/com.GGG.PathOfExile/Logs/Client.txt')
   ] : []
 
 export class GameLogWatcher {


### PR DESCRIPTION
This change sets the default paths for the official and the Steam client on Linux.

I saw that there was an older PR, which attempted to set the default paths on Linux:
https://github.com/SnosMe/awakened-poe-trade/pull/236

Since then, the structure of this project changed and Steam also moved their default location from `.steam` to `.local/share/steam`. 