### PR TITLE
Fixed --proxy-server support

### DIFF
--- a/main/package.json
+++ b/main/package.json
@@ -17,6 +17,7 @@
   "main": "dist/main.js",
   "dependencies": {
     "electron-overlay-window": "3.3.0",
+    "https-proxy-agent": "^7.0.5",
     "uiohook-napi": "1.5.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Due to the implementation of proxy.ts, requests were sent directly, ignoring the --proxy-server setting.
This could have been critical for some users whose IP addresses were on blacklists.
Fixes #1120 