### PR TITLE
fix stuck windows in macos by enabling hw acceleration

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -19,7 +19,9 @@ if (!app.requestSingleInstanceLock()) {
   app.exit()
 }
 
-app.disableHardwareAcceleration()
+if (process.platform !== 'darwin') {
+  app.disableHardwareAcceleration()
+}
 app.enableSandbox()
 
 let tray: AppTray


### PR DESCRIPTION
Built and tested on

```
Darwin 23.5.0 Darwin Kernel Version 23.5.0:
ProductName:		macOS
ProductVersion:		14.5
BuildVersion:		23F79
```

based on https://github.com/SnosMe/awakened-poe-trade/pull/1418.
@SnosMe thanks for all the great work.