### PR TITLE
feat: Add possibility to price check quality on all items

### DIFF
--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -189,11 +189,9 @@ export function createFilters (
   }
 
   if (item.quality && item.quality >= 20) {
-    if (item.category === ItemCategory.Flask || item.category === ItemCategory.Tincture) {
-      filters.quality = {
-        value: item.quality,
-        disabled: (item.quality <= 20)
-      }
+    filters.quality = {
+      value: item.quality,
+      disabled: (item.quality <= 20)
     }
   }
 


### PR DESCRIPTION
This change allows all items with a quality greater than 20 to be searchable when price checking items.
Before this change it was only possible to price check quality on flasks and tinctures.