### PR TITLE
adding ability to use POESESSID for Price Check (private leagues don't work without manually logging in via the buildt-in browser)

### DIFF
--- a/main/src/proxy.ts
+++ b/main/src/proxy.ts
@@ -27,6 +27,11 @@ export class HttpProxy {
         if (key.startsWith('sec-') || key === 'host' || key === 'origin' || key === 'content-length') {
           delete req.headers[key]
         }
+
+        if (key == 'poesessid') {
+          req.headers.cookie = 'POESESSID=' + (req.headers['poesessid'] ?? '');
+          delete req.headers['poesessid'];
+        }
       }
 
       const proxyReq = net.request({
@@ -36,14 +41,14 @@ export class HttpProxy {
           ...req.headers,
           'user-agent': app.userAgentFallback
         },
-        useSessionCookies: true
+        useSessionCookies: false
       })
       proxyReq.addListener('response', (proxyRes) => {
         const resHeaders = { ...proxyRes.headers }
         // `net.request` returns an already decoded body
         delete resHeaders['content-encoding']
         res.writeHead(proxyRes.statusCode, proxyRes.statusMessage, resHeaders)
-        ;(proxyRes as unknown as NodeJS.ReadableStream).pipe(res)
+          ;(proxyRes as unknown as NodeJS.ReadableStream).pipe(res)
       })
       proxyReq.addListener('error', (err) => {
         logger.write(`error [cors-proxy] ${err.message} (${host})`)

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -301,7 +301,8 @@
     "poe_cfg_file" :"PoE config file",
     "restore_clipboard" :"Restore clipboard",
     "show_overlay_ready" :"Show a notification when the Overlay detects a PoE window",
-    "debug_hotkeys": "Record all key presses"
+    "debug_hotkeys": "Record all key presses",
+    "poesessid": "Session ID (POESESSID)"
   },
   "price_check": {
     "name": "Price check",

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -98,6 +98,7 @@ export function poeWebApi () {
 export interface Config {
   configVersion: number
   leagueId?: string
+  poesessid: string
   overlayKey: string
   overlayBackground: string
   overlayBackgroundClose: boolean
@@ -157,6 +158,7 @@ export const defaultConfig = (): Config => ({
   windowTitle: 'Path of Exile',
   logKeys: false,
   accountName: '',
+  poesessid: '',
   stashScroll: true,
   language: 'en',
   realm: 'pc-ggg',

--- a/renderer/src/web/background/Leagues.ts
+++ b/renderer/src/web/background/Leagues.ts
@@ -50,7 +50,11 @@ export const useLeagues = createGlobalState(() => {
     error.value = null
 
     try {
-      const response = await Host.proxy(`${poeWebApi()}/api/leagues?type=main&realm=pc`)
+      const response = await Host.proxy(`${poeWebApi()}/api/leagues?type=main&realm=pc`, {
+        headers: {
+          'poesessid': AppConfig().poesessid
+        }
+      })
       if (!response.ok) throw new Error(JSON.stringify(Object.fromEntries(response.headers)))
       const leagues: ApiLeague[] = await response.json()
       tradeLeagues.value = leagues

--- a/renderer/src/web/price-check/settings-price-check.vue
+++ b/renderer/src/web/price-check/settings-price-check.vue
@@ -15,6 +15,10 @@
           <div class="text-gray-500">{{ t('settings.private_league') }}</div>
           <input v-model="customLeagueId" placeholder="My League (PL12345)" class="rounded bg-gray-900 px-1 mb-1 flex-1" />
         </div>
+        <div class="flex gap-x-2 mb-4">
+          <div class="text-gray-500">{{ t('settings.poesessid') }}</div>
+          <input v-model="poesessid" placeholder="" class="rounded bg-gray-900 px-1 mb-1 flex-1" />
+        </div>
       </template>
     </div>
     <ui-error-box v-else class="mb-4">
@@ -122,6 +126,7 @@ export default defineComponent({
           : '',
         set: (value) => { props.config.leagueId = value }
       }),
+      poesessid: configModelValue(() => props.config, 'poesessid'),
       accountName: configModelValue(() => props.config, 'accountName'),
       showSeller: configModelValue(() => configWidget.value, 'showSeller'),
       activateStockFilter: configModelValue(() => configWidget.value, 'activateStockFilter'),

--- a/renderer/src/web/price-check/trade/pathofexile-bulk.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-bulk.ts
@@ -5,6 +5,7 @@ import { RateLimiter } from './RateLimiter'
 import { ItemFilters } from '../filters/interfaces'
 import { ParsedItem } from '@/parser'
 import { Cache } from './Cache'
+import { AppConfig } from '@/web/Config'
 
 interface TradeRequest { /* eslint-disable camelcase */
   engine: 'new'
@@ -70,7 +71,8 @@ async function requestTradeResultList (body: TradeRequest, leagueId: string): Pr
       method: 'POST',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'poesessid': AppConfig().poesessid
       },
       body: JSON.stringify(body)
     })

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -8,6 +8,7 @@ import { STAT_BY_REF } from '@/assets/data'
 import { RateLimiter } from './RateLimiter'
 import { ModifierType } from '@/parser/modifiers'
 import { Cache } from './Cache'
+import { AppConfig } from '@/web/Config'
 
 export const CATEGORY_TO_TRADE_ID = new Map([
   [ItemCategory.Map, 'map'],
@@ -532,7 +533,8 @@ export async function requestTradeResultList (body: TradeRequest, leagueId: stri
       method: 'POST',
       headers: {
         'Accept': 'application/json',
-        'Content-Type': 'application/json'
+        'Content-Type': 'application/json',
+        'poesessid': AppConfig().poesessid
       },
       body: JSON.stringify(body)
     })
@@ -561,7 +563,11 @@ export async function requestResults (
   if (!data) {
     await RateLimiter.waitMulti(RATE_LIMIT_RULES.FETCH)
 
-    const response = await Host.proxy(`${getTradeEndpoint()}/api/trade/fetch/${resultIds.join(',')}?query=${queryId}`)
+    const response = await Host.proxy(`${getTradeEndpoint()}/api/trade/fetch/${resultIds.join(',')}?query=${queryId}`, {
+      headers: {
+        'poesessid': AppConfig().poesessid
+      }
+    })
     adjustRateLimits(RATE_LIMIT_RULES.FETCH, response.headers)
 
     const _data = await response.json() as TradeResponse<{ result: Array<FetchResult | null> }>
@@ -619,17 +625,17 @@ function tradeIdToQuery (id: string, stat: StatFilter) {
     if (stat.roll?.value === 100) {
       roll = undefined // stat semantic type is flag
     }
-  // fixes "Cannot be Poisoned" from Essence
+    // fixes "Cannot be Poisoned" from Essence
   } else if (id === 'explicit.stat_3835551335') {
     if (stat.roll?.value === 100) {
       roll = undefined // stat semantic type is flag
     }
-  // fixes "Instant Recovery" on Flasks
+    // fixes "Instant Recovery" on Flasks
   } else if (id.endsWith('stat_1526933524')) {
     if (stat.roll?.value === 100) {
       roll = undefined // stat semantic type is flag
     }
-  // fixes Delve "Reservation Efficiency of Skills"
+    // fixes Delve "Reservation Efficiency of Skills"
   } else if (id.endsWith('stat_1269219558')) {
     roll = { ...roll!, tradeInvert: !(roll!.tradeInvert) }
   }


### PR DESCRIPTION
I was hesitant to enter my credentials into anything other than my main browser, so I extended the UI to accept a `POSESSID` alongside the configurable private league.

This is a simple implementation that changes `useSessionCookies` from `true` to `false`, but I'm unsure of any potential side effects.

![image](https://github.com/user-attachments/assets/25ae10f2-96d0-4b29-b6ae-2e9b36d6f9e7)

