### PR TITLE
Fixes all items showing as in dump tab

### DIFF
--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "awakened-poe-trade",
-  "version": "3.25.102",
+  "version": "3.26.101",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "awakened-poe-trade",
-      "version": "3.25.102",
+      "version": "3.26.101",
       "dependencies": {
         "electron-overlay-window": "3.3.0",
         "uiohook-napi": "1.5.x"

--- a/renderer/src/web/price-check/trade/TradeListing.vue
+++ b/renderer/src/web/price-check/trade/TradeListing.vue
@@ -46,7 +46,7 @@
               <td colspan="100" class="text-transparent">***</td>
             </tr>
             <tr v-else :key="result.id">
-              <td class="px-2 whitespace-nowrap"><span :class="{ 'line-through': result.priceCurrency === 'exalted' }">{{ result.priceAmount }} {{ result.priceCurrency }}</span> <span v-if="result.listedTimes > 2" class="rounded px-1 text-gray-800 bg-gray-400 -mr-2"><span class="font-sans">×</span> {{ result.listedTimes }}</span><i v-else-if="!result.hasNote" class="fas fa-question" /></td>
+              <td class="px-2 whitespace-nowrap"><span :class="{ 'line-through': result.priceCurrency === 'exalted' }">{{ result.priceAmount }} {{ result.priceCurrency }}</span> <span v-if="result.listedTimes > 2" class="rounded px-1 text-gray-800 bg-gray-400 -mr-2"><span class="font-sans">×</span> {{ result.listedTimes }}</span><i v-else-if="!result.isIndividuallyPriced" class="fas fa-question" /></td>
               <td v-if="item.stackSize" class="px-2 text-right">{{ result.stackSize }}</td>
               <td v-if="filters.itemLevel" class="px-2 whitespace-nowrap text-right">{{ result.itemLevel }}</td>
               <td v-if="item.category === 'Gem'" class="pl-2 whitespace-nowrap">{{ result.level }}</td>

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -217,10 +217,13 @@ interface FetchResult {
   }
   listing: {
     indexed: string
+    stash?: {
+      name: string
+    }
     price?: {
       amount: number
       currency: string
-      type: '~price'
+      type: '~price' | '~b/o'
     }
     account: Account
   }
@@ -237,7 +240,7 @@ export interface PricingResult {
   priceAmount: number
   priceCurrency: string
   isMine: boolean
-  hasNote: boolean
+  isIndividuallyPriced: boolean
   accountName: string
   accountStatus: 'offline' | 'online' | 'afk'
   ign: string
@@ -586,7 +589,7 @@ export async function requestResults (
       relativeDate: DateTime.fromISO(result.listing.indexed).toRelative({ style: 'short' }) ?? '',
       priceAmount: result.listing.price?.amount ?? 0,
       priceCurrency: result.listing.price?.currency ?? 'no price',
-      hasNote: result.item.note != null,
+      isIndividuallyPriced: isIndividuallyPriced(result),
       isMine: (result.listing.account.name === opts.accountName),
       ign: result.listing.account.lastCharacterName,
       accountName: result.listing.account.name,
@@ -595,6 +598,17 @@ export async function requestResults (
         : 'offline'
     }
   })
+}
+
+function isIndividuallyPriced (result: FetchResult) {
+  const stashName = result.listing.stash?.name
+  const price = result.listing.price
+
+  if (!stashName || !price) {
+    return false
+  }
+
+  return stashName !== `${price.type} ${price.amount} ${price.currency}`
 }
 
 function getMinMax (roll: StatFilter['roll']) {


### PR DESCRIPTION
Fixes #1617, where all listings appear as if in a dump tab. Renames variable since it is no longer checking if there is a note.
This does also bump package lock version since that was updated when I ran APT to test, let me know if that isn't  wanted and i can drop it. 