### PR TITLE
Enable awakened gem quality check

### DIFF
--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -374,10 +374,11 @@ function createGemFilters (
       disabled: (item.gemLevel! < 5)
     }
 
-    if (item.isCorrupted && item.quality) {
+    if (item.quality) {
+      
       filters.quality = {
         value: item.quality,
-        disabled: (item.quality < 20)
+        disabled: (item.isCorrupted && item.quality < 20)
       }
     }
 


### PR DESCRIPTION
Current (Disable Awakened gem quality search unless they are corrupted and 20+ quality)
<img width="1030" height="428" alt="image" src="https://github.com/user-attachments/assets/63b5fe09-89bf-4e5b-94bc-ee71bf1e683b" />

After
<img width="1037" height="651" alt="image" src="https://github.com/user-attachments/assets/e7438859-35bc-4f75-9069-815bf55a12f4" />

