### PR TITLE
Allows parsing for Valdo map rewards

### DIFF
--- a/renderer/public/data/cmn-Hant/client_strings.js
+++ b/renderer/public/data/cmn-Hant/client_strings.js
@@ -10,6 +10,7 @@ export default {
   RARITY_DIVCARD: '命運卡',
   RARITY_QUEST: '任務',
   MAP_TIER: '地圖階級: ',
+  MAP_COMPLETION_REWARD: 'MISSING_TRANSLATION',
   RARITY: '稀有度: ',
   ITEM_CLASS: '物品種類: ',
   ITEM_LEVEL: '物品等級: ',

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -91,7 +91,8 @@
     "veiled": "Veiled",
     "foil_unique": "Foil Unique",
     "mirrored": "Mirrored",
-    "not_mirrored": "Not Mirrored"
+    "not_mirrored": "Not Mirrored",
+    "foil_item": "Foil {0}"
   },
   "item_category": {
     "prop": "Category: {0}",

--- a/renderer/public/data/en/client_strings.js
+++ b/renderer/public/data/en/client_strings.js
@@ -10,6 +10,7 @@ export default {
   RARITY_DIVCARD: 'Divination Card',
   RARITY_QUEST: 'Quest',
   MAP_TIER: 'Map Tier: ',
+  MAP_COMPLETION_REWARD: 'Reward: Foil ',
   RARITY: 'Rarity: ',
   ITEM_CLASS: 'Item Class: ',
   ITEM_LEVEL: 'Item Level: ',

--- a/renderer/public/data/ko/app_i18n.json
+++ b/renderer/public/data/ko/app_i18n.json
@@ -88,7 +88,8 @@
     "veiled": "장막 속성",
     "foil_unique": "반짝이",
     "mirrored": "복제된",
-    "not_mirrored": "복제되지 않은"
+    "not_mirrored": "복제되지 않은",
+    "foil_item": "반짝이 {0}"
   },
   "item_category": {
     "prop": "유형: {0}",

--- a/renderer/public/data/ko/client_strings.js
+++ b/renderer/public/data/ko/client_strings.js
@@ -10,6 +10,7 @@ export default {
   RARITY_DIVCARD: '점술 카드',
   RARITY_QUEST: '퀘스트',
   MAP_TIER: '지도 등급: ',
+  MAP_COMPLETION_REWARD: '보상: 반짝이 ',
   RARITY: '아이템 희귀도: ',
   ITEM_CLASS: '아이템 종류: ',
   ITEM_LEVEL: '아이템 레벨: ',

--- a/renderer/public/data/ru/app_i18n.json
+++ b/renderer/public/data/ru/app_i18n.json
@@ -108,7 +108,8 @@
     "veiled": "Завуалирован",
     "foil_unique": "Реликвия",
     "mirrored": "Отражено",
-    "not_mirrored": "Не отражено"
+    "not_mirrored": "Не отражено",
+    "foil_item": "Особая {0}"
   },
   "item_category": {
     "prop": "Категория: {0}",

--- a/renderer/public/data/ru/client_strings.js
+++ b/renderer/public/data/ru/client_strings.js
@@ -10,6 +10,7 @@ export default {
   RARITY_DIVCARD: 'Гадальная карта',
   RARITY_QUEST: 'Задание',
   MAP_TIER: 'Уровень карты: ',
+  MAP_COMPLETION_REWARD: 'Награда: Особая ',
   RARITY: 'Редкость: ',
   ITEM_CLASS: 'Класс предмета: ',
   ITEM_LEVEL: 'Уровень предмета: ',

--- a/renderer/src/assets/data/interfaces.ts
+++ b/renderer/src/assets/data/interfaces.ts
@@ -98,6 +98,7 @@ export interface TranslationDict {
   RARITY_DIVCARD: string
   RARITY_QUEST: string
   MAP_TIER: string
+  MAP_COMPLETION_REWARD: string
   RARITY: string
   ITEM_CLASS: string
   ITEM_LEVEL: string

--- a/renderer/src/parser/ParsedItem.ts
+++ b/renderer/src/parser/ParsedItem.ts
@@ -34,6 +34,7 @@ export interface ParsedItem {
   weaponELEMENTAL?: number
   mapBlighted?: 'Blighted' | 'Blight-ravaged'
   mapTier?: number
+  mapCompletionReward?: string
   gemLevel?: number
   areaLevel?: number
   talismanTier?: number

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -212,8 +212,18 @@ function findInDatabase (item: ParserState) {
 function parseMap (section: string[], item: ParsedItem) {
   if (section[0].startsWith(_$.MAP_TIER)) {
     item.mapTier = Number(section[0].slice(_$.MAP_TIER.length))
+
+    const foundValdoReward = section.find((sect) => sect.startsWith(_$.MAP_COMPLETION_REWARD))
+
+    if (foundValdoReward) {
+      item.mapCompletionReward = String(
+        foundValdoReward.slice(_$.MAP_COMPLETION_REWARD.length)
+      )
+    }
+
     return 'SECTION_PARSED'
   }
+
   return 'SECTION_SKIPPED'
 }
 

--- a/renderer/src/web/price-check/filters/FiltersBlock.vue
+++ b/renderer/src/web/price-check/filters/FiltersBlock.vue
@@ -5,6 +5,8 @@
         :filter="filters.linkedSockets" :name="t('item.linked_sockets')" />
       <filter-btn-numeric v-if="filters.mapTier"
         :filter="filters.mapTier" :name="t('item.map_tier')" />
+      <filter-btn-logical v-if="filters.mapCompletionReward" readonly
+        :filter="{ disabled: false }" :text="t('item.foil_item', [item.mapCompletionReward])" />
       <filter-btn-numeric v-if="filters.areaLevel"
         :filter="filters.areaLevel" :name="t('item.area_level')" />
       <filter-btn-numeric v-if="filters.heistWingsRevealed"

--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -119,6 +119,10 @@ export function createFilters (
       filters.mapBlighted = { value: item.mapBlighted }
     }
 
+    if (item.mapCompletionReward) {
+      filters.mapCompletionReward = { value: item.mapCompletionReward }
+    }
+
     filters.mapTier = {
       value: item.mapTier!,
       disabled: false

--- a/renderer/src/web/price-check/filters/interfaces.ts
+++ b/renderer/src/web/price-check/filters/interfaces.ts
@@ -51,6 +51,9 @@ export interface ItemFilters {
   mapBlighted?: {
     value: NonNullable<ParsedItem['mapBlighted']>
   }
+  mapCompletionReward?: {
+    value: string
+  }
   itemLevel?: FilterNumeric
   stackSize?: FilterNumeric
   unidentified?: {

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -157,6 +157,7 @@ interface TradeRequest { /* eslint-disable camelcase */
           map_blighted?: FilterBoolean
           map_uberblighted?: FilterBoolean
           area_level?: FilterRange
+          map_completion_reward: 'any' | string
         }
       }
       heist_filters?: {
@@ -360,6 +361,16 @@ export function createTradeRequest (filters: ItemFilters, stats: StatFilter[], i
       propSet(query.filters, 'map_filters.filters.map_blighted.option', String(true))
     } else if (filters.mapBlighted.value === 'Blight-ravaged') {
       propSet(query.filters, 'map_filters.filters.map_uberblighted.option', String(true))
+    }
+  }
+
+  if (filters.mapCompletionReward) {
+    if (filters.mapCompletionReward.value) {
+      propSet(
+        query.filters,
+        'map_filters.filters.map_completion_reward.option',
+        String(filters.mapCompletionReward.value || 'any')
+      )
     }
   }
 


### PR DESCRIPTION
## What
Allows parsing for Valdo (T17) map rewards, showing the current item being checked in the UI, and correctly returning prices for the given item, instead of generally searching for any Valdo's, as it's the current state.

<img width="638" height="1079" alt="image" src="https://github.com/user-attachments/assets/7483d2d3-7517-4f28-9272-94c034856ee4" />
