### PR TITLE
allows pricing quality armor/weapons esp. over 20 qual

### DIFF
--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -4,6 +4,7 @@ import { tradeTag } from '../trade/common'
 import { ModifierType } from '@/parser/modifiers'
 import { BaseType, ITEM_BY_REF } from '@/assets/data'
 import { CATEGORY_TO_TRADE_ID } from '../trade/pathofexile-trade'
+import { ARMOUR, WEAPON } from '@/parser/meta'
 
 export const SPECIAL_SUPPORT_GEM = ['Empower Support', 'Enlighten Support', 'Enhance Support']
 
@@ -192,7 +193,16 @@ export function createFilters (
   }
 
   if (item.quality && item.quality >= 20) {
-    if (item.category === ItemCategory.Flask || item.category === ItemCategory.Tincture) {
+    const applicableQualityCategories = [
+      ItemCategory.Flask,
+      ItemCategory.Tincture,
+      ...WEAPON,
+      ...ARMOUR
+    ]
+
+    const doesQualityApplyForCategory = item.category ? applicableQualityCategories.includes(item.category) : false
+
+    if (doesQualityApplyForCategory) {
       filters.quality = {
         value: item.quality,
         disabled: (item.quality <= 20)

--- a/renderer/src/web/price-check/filters/create-presets.ts
+++ b/renderer/src/web/price-check/filters/create-presets.ts
@@ -63,7 +63,6 @@ export function createPresets (
   const likelyFinishedItem = (
     item.rarity === ItemRarity.Unique ||
     item.statsByType.some(calc => calc.type === ModifierType.Crafted) ||
-    item.quality === 20 || // quality > 20 can be used for selling bases, quality < 20 drops sometimes
     item.isCorrupted ||
     item.isMirrored
   )


### PR DESCRIPTION
## What
- Allows pricing quality armor and weapon bases, especially after the 3.25 changes on how items with >20% quality are obtained, since now anything over 20% quality very heavily increases its price.
- Removes quality === 20 from the likely finished item since quality doesn't really reflect an item being done or not.

<img width="1037" height="481" alt="image" src="https://github.com/user-attachments/assets/06d523f2-42bb-4fac-ae3c-134aa9d93836" />
