### PR TITLE
Forbidden Tomes now check for exact itemLevel

### DIFF
--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -99,21 +99,15 @@ export function createFilters (
         disabled: false
       }
     }
-    if (item.info.refName === 'Forbidden Tome') {
-      if (item.itemLevel) {
-        filters.itemLevel = {
-          value: item.itemLevel!,
-          max: item.itemLevel,
-          disabled: false
-        }
-      }
-      return filters
-    }
-    // Incubators, Wombgifts
+    // Incubators, Wombgifts, Forbidden Tome
     if (item.itemLevel) {
       filters.itemLevel = {
         value: item.itemLevel,
         disabled: false
+      }
+
+      if (item.info.refName === 'Forbidden Tome') {
+        filters.itemLevel.max = item.itemLevel
       }
     }
     return filters


### PR DESCRIPTION
Forbidden Tome prices are very item level sensitive. This fixes low item level tomes showing much lower values than they are worth.