### PR TITLE
bugfix: MacOS Native App Crash Fix Issue-1153

### DIFF
--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -1,6 +1,6 @@
 'use strict'
 
-import { app } from 'electron'
+import { app, dialog, shell, systemPreferences } from 'electron'
 import { uIOhook } from 'uiohook-napi'
 import os from 'node:os'
 import { startServer, eventPipe, server } from './server'
@@ -23,6 +23,11 @@ if (process.platform !== 'darwin') {
   app.disableHardwareAcceleration()
 }
 app.enableSandbox()
+
+function canStartUiohook () {
+  return process.platform !== 'darwin' ||
+    systemPreferences.isTrustedAccessibilityClient(false)
+}
 
 let tray: AppTray
 
@@ -48,7 +53,24 @@ app.on('ready', async () => {
         appUpdater.checkAtStartup()
         tray.overlayKey = cfg.overlayKey
       })
-      uIOhook.start()
+      if (canStartUiohook()) {
+        uIOhook.start()
+      } else {
+        const needsRestart = dialog.showMessageBoxSync({
+          type: 'warning',
+          title: 'Accessibility Permission Required',
+          message: 'Awakened PoE Trade needs Accessibility permission to capture shortcuts on macOS.',
+          detail:
+            'Open System Settings > Privacy & Security > Accessibility and allow this app/Terminal.\n\n' +
+            'After enabling, restart the app.',
+          buttons: ['Open Settings', 'Later'],
+          defaultId: 0,
+          cancelId: 1
+        })
+        if (needsRestart === 0) {
+          await shell.openExternal('x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility')
+        }
+      }
       const port = await startServer(appUpdater, logger)
       // TODO: move up (currently crashes)
       logger.write(`info ${os.type()} ${os.release} / v${app.getVersion()}`)


### PR DESCRIPTION
## Title
fix(macOS): handle missing Accessibility permission before starting uIOhook

## Summary
This PR improves macOS permission handling for global shortcut capture.

When Accessibility permission is not granted, the app now:
- does **not** start `uIOhook`
- shows a warning dialog explaining what is required
- provides an **Open Settings** action to jump directly to Accessibility settings
- asks the user to restart after enabling permission

On non-macOS platforms, behavior is unchanged.

## What changed
- Added Electron imports: `dialog`, `shell`, `systemPreferences`
- Added `canStartUiohook()` helper:
  - returns `true` on non-macOS
  - on macOS, checks `systemPreferences.isTrustedAccessibilityClient(false)`
- Updated app startup flow:
  - start `uIOhook` only when permission is available
  - otherwise show a permission guidance dialog
  - open macOS Accessibility settings via:
    - `x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility`

## Why
Previously, `uIOhook.start()` was called unconditionally.  
On macOS, this could fail silently or confuse users when Accessibility permission had not been granted.

## Manual tested

On
* POE running on CrossOver
* Awaken POE Trade running on dev (This fix is for Mac Natvie App, not for running app from awaken from crossover)

1. macOS with Accessibility permission **disabled**
2. Launch app
3. Verify warning dialog appears
4. Click **Open Settings** and confirm System Settings opens Accessibility page
5. Enable permission and restart app
6. Verify shortcut capture works and app starts normally
<img width="265" height="341" alt="image" src="https://github.com/user-attachments/assets/2a5c2d77-3a76-43e9-84cb-769c62ced8be" />
<img width="883" height="419" alt="image" src="https://github.com/user-attachments/assets/b43aedee-7b5d-4a2c-b3d8-6ef29916ee2c" />
