### PR TITLE
fix: use xdotool for Linux chat input — uiohook keyTap drops Ctrl modifier

### DIFF
--- a/main/src/shortcuts/text-box.ts
+++ b/main/src/shortcuts/text-box.ts
@@ -1,4 +1,5 @@
 import { uIOhook, UiohookKey as Key } from 'uiohook-napi'
+import { execSync } from 'child_process'
 import process from 'process';
 import type { HostClipboard } from './HostClipboard'
 import type { OverlayWindow } from '../windowing/OverlayWindow'
@@ -13,6 +14,15 @@ const AUTO_CLEAR = [
   '/' // Command
 ]
 
+const IS_LINUX = process.platform === 'linux'
+
+// On Linux/X11, uiohook's keyTap with modifiers doesn't reliably deliver
+// Ctrl+V to the game — the modifier gets lost and bare 'v' is typed.
+// xdotool handles X11 input simulation correctly.
+function xdotoolKey (keys: string) {
+  execSync(`xdotool key --delay 20 ${keys}`, { timeout: 2000 })
+}
+
 export function typeInChat (text: string, send: boolean, clipboard: HostClipboard) {
   clipboard.restoreShortly((clipboard) => {
     const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
@@ -20,34 +30,68 @@ export function typeInChat (text: string, send: boolean, clipboard: HostClipboar
     if (text.startsWith(PLACEHOLDER_LAST)) {
       text = text.slice(`${PLACEHOLDER_LAST} `.length)
       clipboard.writeText(text)
-      uIOhook.keyTap(Key.Enter, modifiers)
+      if (IS_LINUX) {
+        xdotoolKey('ctrl+Return')
+        setTimeout(() => {
+          xdotoolKey('ctrl+v')
+          if (send) linuxSend()
+        }, 50)
+      } else {
+        uIOhook.keyTap(Key.Enter, modifiers)
+        uIOhook.keyTap(Key.V, modifiers)
+        if (send) _send()
+      }
     } else if (text.endsWith(PLACEHOLDER_LAST)) {
       text = text.slice(0, -PLACEHOLDER_LAST.length)
       clipboard.writeText(text)
-      uIOhook.keyTap(Key.Enter, modifiers)
-      uIOhook.keyTap(Key.Home)
-      // press twice to focus input when using controller
-      uIOhook.keyTap(Key.Home)
-      uIOhook.keyTap(Key.Delete)
+      if (IS_LINUX) {
+        xdotoolKey('ctrl+Return')
+        xdotoolKey('Home Home Delete')
+        setTimeout(() => {
+          xdotoolKey('ctrl+v')
+          if (send) linuxSend()
+        }, 50)
+      } else {
+        uIOhook.keyTap(Key.Enter, modifiers)
+        uIOhook.keyTap(Key.Home)
+        uIOhook.keyTap(Key.Home)
+        uIOhook.keyTap(Key.Delete)
+        uIOhook.keyTap(Key.V, modifiers)
+        if (send) _send()
+      }
     } else {
       clipboard.writeText(text)
-      uIOhook.keyTap(Key.Enter)
-      if (!AUTO_CLEAR.includes(text[0])) {
-        uIOhook.keyTap(Key.A, modifiers)
+      if (IS_LINUX) {
+        xdotoolKey('Return')
+        setTimeout(() => {
+          if (!AUTO_CLEAR.includes(text[0])) {
+            xdotoolKey('ctrl+a')
+          }
+          xdotoolKey('ctrl+v')
+          if (send) linuxSend()
+        }, 50)
+      } else {
+        uIOhook.keyTap(Key.Enter)
+        if (!AUTO_CLEAR.includes(text[0])) {
+          uIOhook.keyTap(Key.A, modifiers)
+        }
+        uIOhook.keyTap(Key.V, modifiers)
+        if (send) _send()
       }
     }
-
-    uIOhook.keyTap(Key.V, modifiers)
-
-    if (send) {
-      uIOhook.keyTap(Key.Enter)
-      // restore the last chat
-      uIOhook.keyTap(Key.Enter)
-      uIOhook.keyTap(Key.ArrowUp)
-      uIOhook.keyTap(Key.ArrowUp)
-      uIOhook.keyTap(Key.Escape)
-    }
   })
+}
+
+function _send () {
+  uIOhook.keyTap(Key.Enter)
+  uIOhook.keyTap(Key.Enter)
+  uIOhook.keyTap(Key.ArrowUp)
+  uIOhook.keyTap(Key.ArrowUp)
+  uIOhook.keyTap(Key.Escape)
+}
+
+function linuxSend () {
+  xdotoolKey('Return Return Up Up Escape')
 }
 
 export function stashSearch (
@@ -58,8 +102,14 @@ export function stashSearch (
   clipboard.restoreShortly((clipboard) => {
     overlay.assertGameActive()
     clipboard.writeText(text)
-    uIOhook.keyTap(Key.F, [Key.Ctrl])
-    uIOhook.keyTap(Key.V, [process.platform === 'darwin' ? Key.Meta : Key.Ctrl])
-    uIOhook.keyTap(Key.Enter)
+    if (IS_LINUX) {
+      xdotoolKey('ctrl+f')
+      xdotoolKey('ctrl+v')
+      xdotoolKey('Return')
+    } else {
+      uIOhook.keyTap(Key.F, [Key.Ctrl])
+      uIOhook.keyTap(Key.V, [process.platform === 'darwin' ? Key.Meta : Key.Ctrl])
+      uIOhook.keyTap(Key.Enter)
+    }
   })
 }


### PR DESCRIPTION
## Problem

On Linux/X11, `uIOhook.keyTap(Key.V, [Key.Ctrl])` in `typeInChat` drops the Ctrl modifier — only the bare `v` keystroke reaches the game. This breaks all chat commands (`/hideout`, whispers, etc.) and has been broken on Linux for years.

The root cause is that uiohook-napi's native X11 key simulation (via XTest) fires modifier down/key/modifier up events too fast for Wine/PoE to process correctly. The Ctrl press never registers.

## Fix

On Linux, use `xdotool` for all key simulation in `typeInChat` and `stashSearch`. xdotool's `--delay 20` flag spaces events correctly for X11, and its modifier handling is battle-tested.

A 50ms `setTimeout` between Enter (open chat) and Ctrl+V (paste) gives X11 time to focus the chat input.

Windows and macOS codepaths are completely unchanged — the existing uiohook calls are preserved behind `IS_LINUX` guards.

**Requires:** `xdotool` (`apt install xdotool`)

## Changes

- `text-box.ts`: Add `xdotool` codepath gated on `process.platform === 'linux'`
- All three `typeInChat` branches (normal, `@last` prefix, `@last` suffix) and `stashSearch` use xdotool on Linux
- Zero changes to Windows/macOS behavior

## Testing

Tested on Ubuntu 24.04 with PoE2. F5 → `/hideout` correctly opens local chat and pastes the full command.