### PR TITLE
fix: use xdotool for Linux chat input

### DIFF
--- a/main/src/shortcuts/text-box.ts
+++ b/main/src/shortcuts/text-box.ts
@@ -1,4 +1,5 @@
 import { uIOhook, UiohookKey as Key } from 'uiohook-napi'
+import { execFileSync } from 'child_process'
 import process from 'process';
 import type { HostClipboard } from './HostClipboard'
 import type { OverlayWindow } from '../windowing/OverlayWindow'
@@ -13,24 +14,69 @@ const AUTO_CLEAR = [
   '/' // Command
 ]
 
+const IS_LINUX = process.platform === 'linux'
+const XDOTOOL_DELAY_MS = '20'
+let hasXdotool: boolean | undefined
+
+function canUseXdotool () {
+  if (!IS_LINUX) return false
+  if (hasXdotool != null) return hasXdotool
+
+  try {
+    execFileSync('xdotool', ['--version'], { stdio: 'ignore', timeout: 2000 })
+    hasXdotool = true
+  } catch {
+    hasXdotool = false
+  }
+
+  return hasXdotool
+}
+
+function xdotool (...args: string[]) {
+  execFileSync('xdotool', args, { stdio: 'ignore', timeout: 2000 })
+}
+
+function xdotoolChatPaste (text: string, send: boolean) {
+  if (text.startsWith(PLACEHOLDER_LAST)) {
+    xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'ctrl+Return', 'sleep', '0.05', 'key', 'ctrl+v')
+  } else if (text.endsWith(PLACEHOLDER_LAST)) {
+    xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'ctrl+Return', 'sleep', '0.05', 'key', 'Home', 'Home', 'Delete', 'key', 'ctrl+v')
+  } else {
+    xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'Return')
+    if (!AUTO_CLEAR.includes(text[0])) {
+      xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'ctrl+a')
+    }
+    xdotool('sleep', '0.05', 'key', '--delay', XDOTOOL_DELAY_MS, 'ctrl+v')
+  }
+
+  if (send) {
+    xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'Return', 'Return', 'Up', 'Up', 'Escape')
+  }
+}
+
 export function typeInChat (text: string, send: boolean, clipboard: HostClipboard) {
   clipboard.restoreShortly((clipboard) => {
     const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
+    clipboard.writeText(text.startsWith(PLACEHOLDER_LAST)
+      ? text.slice(`${PLACEHOLDER_LAST} `.length)
+      : (text.endsWith(PLACEHOLDER_LAST) ? text.slice(0, -PLACEHOLDER_LAST.length) : text))
+
+    if (canUseXdotool()) {
+      xdotoolChatPaste(text, send)
+      return
+    }
 
     if (text.startsWith(PLACEHOLDER_LAST)) {
       text = text.slice(`${PLACEHOLDER_LAST} `.length)
-      clipboard.writeText(text)
       uIOhook.keyTap(Key.Enter, modifiers)
     } else if (text.endsWith(PLACEHOLDER_LAST)) {
       text = text.slice(0, -PLACEHOLDER_LAST.length)
-      clipboard.writeText(text)
       uIOhook.keyTap(Key.Enter, modifiers)
       uIOhook.keyTap(Key.Home)
       // press twice to focus input when using controller
       uIOhook.keyTap(Key.Home)
       uIOhook.keyTap(Key.Delete)
     } else {
-      clipboard.writeText(text)
       uIOhook.keyTap(Key.Enter)
       if (!AUTO_CLEAR.includes(text[0])) {
         uIOhook.keyTap(Key.A, modifiers)
@@ -58,6 +104,12 @@ export function stashSearch (
   clipboard.restoreShortly((clipboard) => {
     overlay.assertGameActive()
     clipboard.writeText(text)
+
+    if (canUseXdotool()) {
+      xdotool('key', '--delay', XDOTOOL_DELAY_MS, 'ctrl+f', 'sleep', '0.05', 'key', 'ctrl+v', 'key', 'Return')
+      return
+    }
+
     uIOhook.keyTap(Key.F, [Key.Ctrl])
     uIOhook.keyTap(Key.V, [process.platform === 'darwin' ? Key.Meta : Key.Ctrl])
     uIOhook.keyTap(Key.Enter)


### PR DESCRIPTION
## Summary
- use xdotool on Linux for chat command input instead of relying on uiohook modified key taps
- keep the existing uiohook path as a fallback when xdotool is unavailable
- apply the same Linux paste path to stash search because it uses the same Ctrl-modified input flow

## Testing
- verified locally on Linux that F5 now opens chat and pastes /hideout instead of typing plain v
- npm run build in the original clone at /home/ath/Desktop/assistant-PoE/awakened-poe-trade/main
- rebuilt the Linux package and verified the patched binary behavior locally