### PR TITLE
Fix base item search: add synthesised, non-influenced filters and fix split visibility

### DIFF
--- a/renderer/public/data/cmn-Hant/app_i18n.json
+++ b/renderer/public/data/cmn-Hant/app_i18n.json
@@ -27,6 +27,10 @@
     "Refresh": "刷新",
     "map.mods.heist": "劫盜",
     "map.mods.outdated": "過時",
-    "Support development on": "支持開發"
-  
+    "Support development on": "支持開發",
+
+  "item": {
+    "non_influenced": "Non-influenced"
+  }
+
 }

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -98,6 +98,7 @@
     "not_mirrored": "Not Mirrored",
     "split": "Split",
     "not_split": "Not Split",
+    "non_influenced": "Non-influenced",
     "map_foil_reward": "Foil {0}"
   },
   "item_category": {

--- a/renderer/public/data/ko/app_i18n.json
+++ b/renderer/public/data/ko/app_i18n.json
@@ -93,7 +93,8 @@
     "foil_unique": "반짝이",
     "mirrored": "복제된",
     "not_mirrored": "복제되지 않은",
-    "map_foil_reward": "반짝이 {0}"
+    "map_foil_reward": "반짝이 {0}",
+    "non_influenced": "Non-influenced"
   },
   "item_category": {
     "prop": "유형: {0}",

--- a/renderer/public/data/ru/app_i18n.json
+++ b/renderer/public/data/ru/app_i18n.json
@@ -116,6 +116,7 @@
     "not_mirrored": "Не отражено",
     "split": "Разделено",
     "not_split": "Не разделено",
+    "non_influenced": "Без влияния",
     "map_foil_reward": "Особая {0}"
   },
   "item_category": {

--- a/renderer/src/web/price-check/filters/FiltersBlock.vue
+++ b/renderer/src/web/price-check/filters/FiltersBlock.vue
@@ -31,6 +31,8 @@
         <filter-btn-logical v-for="influence of filters.influences" :key="influence.value"
           :filter="influence" :text="influence.value" :img="`/images/influence-${influence.value}.png`" />
       </template>
+      <filter-btn-logical v-if="filters.nonInfluenced"
+        :filter="filters.nonInfluenced" :text="t('item.non_influenced')" />
       <filter-btn-logical v-if="filters.rarity?.value === 'magic'"
         :filter="filters.rarity" text="Magic" />
       <filter-btn-logical v-if="filters.unidentified"

--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -300,16 +300,21 @@ export function createFilters (
   if (item.isSplit) {
     filters.split = { disabled: false, hidden: false }
   } else if (
-    item.info.craftable && !item.isCorrupted && !item.isMirrored &&
-    !item.isSynthesised && !item.isFractured && !item.influences.length
+    item.info.craftable && !item.isCorrupted && !item.isMirrored
   ) {
-    filters.split = { disabled: true, hidden: true }
+    filters.split = { disabled: true, hidden: false }
   }
 
   if (!item.isFractured &&
     (item.info.craftable && !item.isCorrupted && !item.isMirrored)
   ) {
     filters.fractured = { value: false }
+  }
+
+  if (!item.isSynthesised &&
+    (item.info.craftable && !item.isCorrupted && !item.isMirrored)
+  ) {
+    filters.synthesised = { value: false }
   }
 
   if (item.isFoil) {
@@ -321,6 +326,12 @@ export function createFilters (
       value: influence,
       disabled: !opts.exact
     }))
+  }
+
+  if (!item.influences.length &&
+    (item.info.craftable && !item.isCorrupted)
+  ) {
+    filters.nonInfluenced = { disabled: false }
   }
 
   if (item.itemLevel) {

--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -329,7 +329,7 @@ export function createFilters (
   }
 
   if (!item.influences.length &&
-    (item.info.craftable && !item.isCorrupted)
+    (item.info.craftable && !item.isCorrupted && !item.isMirrored)
   ) {
     filters.nonInfluenced = { disabled: false }
   }

--- a/renderer/src/web/price-check/filters/interfaces.ts
+++ b/renderer/src/web/price-check/filters/interfaces.ts
@@ -47,6 +47,12 @@ export interface ItemFilters {
     disabled: boolean
     hidden: boolean
   }
+  synthesised?: {
+    value: false
+  }
+  nonInfluenced?: {
+    disabled: boolean
+  }
   foil?: {
     disabled: boolean
   }

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -128,6 +128,7 @@ interface TradeRequest {
           gem_level?: FilterRange
           corrupted?: FilterBoolean
           fractured_item?: FilterBoolean
+          synthesised_item?: FilterBoolean
           gem_imbued?: FilterBoolean
           mirrored?: FilterBoolean
           split?: FilterBoolean
@@ -321,6 +322,9 @@ export function createTradeRequest (filters: ItemFilters, stats: StatFilter[]) {
   }
   if (filters.fractured?.value === false) {
     propSet(query.filters, 'misc_filters.filters.fractured_item.option', String(false))
+  }
+  if (filters.synthesised?.value === false) {
+    propSet(query.filters, 'misc_filters.filters.synthesised_item.option', String(false))
   }
   if (filters.imbuedGem?.disabled) {
     propSet(query.filters, 'misc_filters.filters.gem_imbued.option', String(false))
@@ -523,6 +527,15 @@ export function createTradeRequest (filters: ItemFilters, stats: StatFilter[]) {
   const qNot: TradeRequest['query']['stats'][number] = {
     type: 'not',
     filters: []
+  }
+
+  if (filters.nonInfluenced && !filters.nonInfluenced.disabled) {
+    const tradeId = pseudoStatByRef(stat('Has # Influences'))!.trade.ids[ModifierType.Pseudo][0]
+    qAnd.filters.push({
+      id: tradeId,
+      value: { max: 0 },
+      disabled: false
+    })
   }
 
   for (const stat of realStats) {


### PR DESCRIPTION
## Summary

Fixes #1769

When price-checking clean base items, search results include synthesised, influenced, and split bases which are always cheaper. This skews the price estimation.

## Changes

* **Split filter**: make "Not Split" button visible for clean bases (was hidden), simplify conditions by removing redundant checks
* **Synthesised filter**: add silent `synthesised_item: false` misc filter for non-synthesised craftable bases (same pattern as existing `fractured` filter)
* **Non-influenced filter**: add visible "Non-influenced" button that uses `Has # Influences` pseudo stat with `max: 0` to exclude influenced bases
* **Trade API**: add `synthesised_item` to `misc_filters` interface and request builder
* **i18n**: add `non_influenced` key in all 4 languages (en, ru, ko, cmn-Hant)