### PR TITLE
Add abyssal sockets filter for price check

### DIFF
--- a/renderer/public/data/cmn-Hant/app_i18n.json
+++ b/renderer/public/data/cmn-Hant/app_i18n.json
@@ -25,6 +25,9 @@
     "scourge": "天災",
     "Not recognized modifier": "無法使用此詞綴",
     "Refresh": "刷新",
+    "item": {
+      "abyssal_sockets": "Abyss: {0}"
+    },
     "map.mods.heist": "劫盜",
     "map.mods.outdated": "過時",
     "Support development on": "支持開發"

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -68,6 +68,7 @@
     "heist_wings_revealed": "Wings Revealed: {0}",
     "linked_sockets": "Links: {0}",
     "white_sockets": "White: {0}",
+    "abyssal_sockets": "Abyss: {0}",
     "quality": "Quality: {0}",
     "memory_strands": "Memory Strands: {0}",
     "gem_level": "Level: {0}",

--- a/renderer/public/data/ko/app_i18n.json
+++ b/renderer/public/data/ko/app_i18n.json
@@ -65,6 +65,7 @@
     "heist_wings_revealed": "드러낸 부속 건물: {0}",
     "linked_sockets": "연결부: {0}",
     "white_sockets": "흰 홈: {0}",
+    "abyssal_sockets": "Abyss: {0}",
     "quality": "퀄리티: {0}",
     "memory_strands": "기억 가닥: {0}",
     "gem_level": "젬 레벨: {0}",

--- a/renderer/public/data/ru/app_i18n.json
+++ b/renderer/public/data/ru/app_i18n.json
@@ -86,6 +86,7 @@
     "heist_wings_revealed": "Крыльев обнаружено: {0}",
     "linked_sockets": "Связи: {0}",
     "white_sockets": "Белые: {0}",
+    "abyssal_sockets": "Бездна: {0}",
     "quality": "Качество: {0}",
     "memory_strands": "Пряди воспоминаний: {0}",
     "gem_level": "Уровень: {0}",

--- a/renderer/src/parser/ParsedItem.ts
+++ b/renderer/src/parser/ParsedItem.ts
@@ -53,6 +53,7 @@ export interface ParsedItem {
   sockets?: {
     linked?: number // only 5 or 6
     white: number
+    abyssal: number
   }
   stackSize?: { value: number, max: number }
   isUnidentified: boolean

--- a/renderer/src/parser/Parser.ts
+++ b/renderer/src/parser/Parser.ts
@@ -553,6 +553,7 @@ function parseSockets (section: string[], item: ParsedItem) {
 
     item.sockets = {
       white: (sockets.split('W').length - 1),
+      abyssal: (sockets.split('A').length - 1),
       linked: undefined
     }
 

--- a/renderer/src/web/price-check/filters/FiltersBlock.vue
+++ b/renderer/src/web/price-check/filters/FiltersBlock.vue
@@ -23,6 +23,8 @@
         :filter="filters.stackSize" :name="t('item.stock')" />
       <filter-btn-numeric v-if="filters.whiteSockets"
         :filter="filters.whiteSockets" :name="t('item.white_sockets')" />
+      <filter-btn-numeric v-if="filters.abyssalSockets"
+        :filter="filters.abyssalSockets" :name="t('item.abyssal_sockets')" />
       <filter-btn-numeric v-if="filters.gemLevel"
         :filter="filters.gemLevel" :name="t('item.gem_level')" />
       <filter-btn-numeric v-if="filters.quality"

--- a/renderer/src/web/price-check/filters/create-item-filters.ts
+++ b/renderer/src/web/price-check/filters/create-item-filters.ts
@@ -246,6 +246,13 @@ export function createFilters (
     }
   }
 
+  if (item.sockets?.abyssal) {
+    filters.abyssalSockets = {
+      value: item.sockets.abyssal,
+      disabled: false
+    }
+  }
+
   const forAdornedJewel = (
     item.rarity === ItemRarity.Magic &&
     // item.isCorrupted && -- let the buyer corrupt

--- a/renderer/src/web/price-check/filters/create-stat-filters.ts
+++ b/renderer/src/web/price-check/filters/create-stat-filters.ts
@@ -426,6 +426,14 @@ function finalFilterTweaks (ctx: FiltersCreationContext) {
     applyFlaskHybridMod(ctx)
   }
 
+  if (item.sockets?.abyssal) {
+    for (const filter of ctx.filters) {
+      if (filter.statRef === 'Has # Abyssal Sockets') {
+        filter.hidden = 'filters.hide_const_roll'
+      }
+    }
+  }
+
   const hasEmptyModifier = showHasEmptyModifier(ctx)
   if (hasEmptyModifier !== false) {
     ctx.filters.push({

--- a/renderer/src/web/price-check/filters/interfaces.ts
+++ b/renderer/src/web/price-check/filters/interfaces.ts
@@ -29,6 +29,7 @@ export interface ItemFilters {
   }
   linkedSockets?: FilterNumeric
   whiteSockets?: FilterNumeric
+  abyssalSockets?: FilterNumeric
   corrupted?: {
     value: boolean
     exact?: boolean

--- a/renderer/src/web/price-check/trade/pathofexile-trade.ts
+++ b/renderer/src/web/price-check/trade/pathofexile-trade.ts
@@ -362,6 +362,17 @@ export function createTradeRequest (filters: ItemFilters, stats: StatFilter[]) {
     propSet(query.filters, 'socket_filters.filters.sockets.w', filters.whiteSockets.value)
   }
 
+  if (filters.abyssalSockets && !filters.abyssalSockets.disabled) {
+    const abyssalStat = STAT_BY_REF_V2(stat('Has # Abyssal Sockets'))!
+    const dbStats = ('stats' in abyssalStat) ? abyssalStat.stats : [abyssalStat]
+    const tradeId = dbStats[0].trade.ids[ModifierType.Explicit][0]
+    query.stats[0].filters.push({
+      id: tradeId,
+      value: { min: filters.abyssalSockets.value },
+      disabled: false
+    })
+  }
+
   if (filters.mapTier && !filters.mapTier.disabled) {
     propSet(query.filters, 'map_filters.filters.map_tier.min', filters.mapTier.value)
     propSet(query.filters, 'map_filters.filters.map_tier.max', filters.mapTier.value)


### PR DESCRIPTION
## Summary

Fixes #1812

Bubonic Trail and other items with abyssal sockets had no dedicated filter in price check UI. The `Has # Abyssal Sockets` stat was sent to the trade site but disabled by default.

## Changes

* Parse "A" (abyssal) sockets from item socket line in `parseSockets`
* Add `abyssalSockets` field to `ParsedItem.sockets` type
* Add dedicated `abyssalSockets` filter with UI button (same pattern as white sockets)
* Query trade API using explicit stat `Has # Abyssal Sockets` with min value
* Hide duplicate stat filter in stat list when dedicated filter is active
* Add i18n keys for all 4 languages (en, ru, ko, cmn-Hant)