### PR TITLE
add per-item auto-search toggle

### DIFF
--- a/renderer/public/data/cmn-Hant/app_i18n.json
+++ b/renderer/public/data/cmn-Hant/app_i18n.json
@@ -27,6 +27,10 @@
     "Refresh": "刷新",
     "map.mods.heist": "劫盜",
     "map.mods.outdated": "過時",
-    "Support development on": "支持開發"
-  
+    "Support development on": "支持開發",
+
+    "filters": {
+      "auto_toggle": "自動"
+    }
+
 }

--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -161,6 +161,7 @@
     "hidden_toggle": "Hidden",
     "collapse": "Collapse",
     "mods_toggle": "Mods",
+    "auto_toggle": "Auto",
     "empty": "No relevant stats were found",
     "tier": "Tier {0}",
     "preset_pseudo": "Pseudo",

--- a/renderer/public/data/ko/app_i18n.json
+++ b/renderer/public/data/ko/app_i18n.json
@@ -153,6 +153,7 @@
     "hidden_toggle": "숨겨진",
     "collapse": "접기",
     "mods_toggle": "모드",
+    "auto_toggle": "자동",
     "empty": "No relevant stats were found",
     "tier": "티어 {0}",
     "preset_pseudo": "Pseudo",

--- a/renderer/public/data/ru/app_i18n.json
+++ b/renderer/public/data/ru/app_i18n.json
@@ -178,6 +178,7 @@
     "hidden_toggle": "Скрытые",
     "collapse": "Свернуть",
     "mods_toggle": "Моды",
+    "auto_toggle": "Авто",
     "empty": "Подходящие свойства не найдены",
     "tier": "Ур {0}",
     "preset_pseudo": "Псевдо",

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -396,6 +396,9 @@ function upgradeConfig (_config: Config): Config {
   if (priceCheck.rememberCurrency === undefined) {
     priceCheck.rememberCurrency = false
   }
+  if (priceCheck.autoSearchDisabled === undefined) {
+    priceCheck.autoSearchDisabled = []
+  }
 
   for (const widget of config.widgets) {
     if (widget.wmType === 'stash-search') {

--- a/renderer/src/web/overlay/widgets.ts
+++ b/renderer/src/web/overlay/widgets.ts
@@ -51,6 +51,7 @@ export interface PriceCheckWidget extends Widget {
   requestPricePrediction: boolean
   builtinBrowser: boolean
   rememberCurrency: boolean
+  autoSearchDisabled: string[]
 }
 
 export interface StopwatchWidget extends Widget {

--- a/renderer/src/web/price-check/CheckedItem.vue
+++ b/renderer/src/web/price-check/CheckedItem.vue
@@ -123,7 +123,7 @@ export default defineComponent({
           (props.advancedCheck && !widget.value.lockedInitialSearch)) {
         doSearch.value = false
       } else {
-        doSearch.value = Boolean(
+        const wouldAutoSearch = Boolean(
           (item.rarity === ItemRarity.Unique) ||
           (item.category === ItemCategory.Map) ||
           (item.category === ItemCategory.HeistContract) ||
@@ -135,6 +135,8 @@ export default defineComponent({
           (item.isUnidentified) ||
           (item.isVeiled)
         )
+        doSearch.value = wouldAutoSearch &&
+          !widget.value.autoSearchDisabled.includes(item.info.refName)
       }
 
       tradeAPI.value = apiToSatisfySearch(props.item, itemStats.value, itemFilters.value)

--- a/renderer/src/web/price-check/PriceCheckWindow.vue
+++ b/renderer/src/web/price-check/PriceCheckWindow.vue
@@ -115,7 +115,8 @@ export default defineComponent({
         searchStatRange: 10,
         showCursor: true,
         requestPricePrediction: false,
-        rememberCurrency: false
+        rememberCurrency: false,
+        autoSearchDisabled: []
       }
     }
   } satisfies WidgetSpec,

--- a/renderer/src/web/price-check/filters/FiltersBlock.vue
+++ b/renderer/src/web/price-check/filters/FiltersBlock.vue
@@ -84,6 +84,9 @@
           v-model="showHidden" class="text-gray-400 pt-2">{{ t('filters.hidden_toggle') }}</ui-toggle>
         <ui-toggle
           v-model="showFilterSources" class="ml-auto text-gray-400 pt-2">{{ t('filters.mods_toggle') }}</ui-toggle>
+        <ui-toggle
+          :modelValue="isAutoSearchEnabled" @update:modelValue="toggleAutoSearch"
+          class="text-gray-400 pt-2">{{ t('filters.auto_toggle') }}</ui-toggle>
       </div>
     </div>
   </div>
@@ -99,6 +102,8 @@ import FilterBtnLogical from './FilterBtnLogical.vue'
 import UnknownModifier from './UnknownModifier.vue'
 import { ItemFilters, StatFilter } from './interfaces'
 import { ParsedItem, ItemRarity, ItemCategory } from '@/parser'
+import { AppConfig } from '@/web/Config'
+import { PriceCheckWidget } from '@/web/overlay/interfaces'
 
 export default defineComponent({
   name: 'FiltersBlock',
@@ -171,6 +176,21 @@ export default defineComponent({
       },
       selectPreset (id: string) {
         ctx.emit('preset', id)
+      },
+      isAutoSearchEnabled: computed(() => {
+        const widget = AppConfig<PriceCheckWidget>('price-check')!
+        return !widget.autoSearchDisabled.includes(props.item.info.refName)
+      }),
+      toggleAutoSearch (enabled: boolean) {
+        const widget = AppConfig<PriceCheckWidget>('price-check')!
+        const list = widget.autoSearchDisabled
+        const refName = props.item.info.refName
+        if (enabled) {
+          const idx = list.indexOf(refName)
+          if (idx !== -1) list.splice(idx, 1)
+        } else {
+          if (!list.includes(refName)) list.push(refName)
+        }
       }
     }
   }


### PR DESCRIPTION
Adds a toggle next to Mods to disable automatic trade search for specific item types. Persists across sessions. Useful when poe.ninja prices are enough.

![Auto-search toggle](https://github.com/user-attachments/assets/7fc895e4-3c69-4eea-9816-99d1963af5a5)