### PR TITLE
Remove system-wide mousemove hook from OverlayVisibility

### DIFF
--- a/main/src/windowing/OverlayVisibility.ts
+++ b/main/src/windowing/OverlayVisibility.ts
@@ -23,10 +23,6 @@ export class OverlayVisibility {
     uIOhook.on('keyup', (e) => {
       if (!e.altKey) { this.makeVisible() }
     })
-
-    uIOhook.on('mousemove', (e) => {
-      if (!e.altKey) { this.makeVisible() }
-    })
   }
 
   private makeVisible () {


### PR DESCRIPTION
 The uiohook mousemove listener in OverlayVisibility fires on every mouse movement system-wide, even when PoE is not the active window. This causes input lag and microstutters in other applications (games, etc.) running alongside Awakened PoE Trade.
 
The mousemove handler is redundan, it only calls makeVisible() to restore overlay visibility after Alt-hide, which the keyup`handler already handles reliably.
