### PR TITLE
linux: update AppRun ozone patch for app-builder-lib 26.15.3

### DIFF
--- a/main/build/app-builder-lib+26.15.3.patch
+++ b/main/build/app-builder-lib+26.15.3.patch
@@ -2,14 +2,14 @@ diff --git a/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js b
 index ee817d1..ef1f916 100644
 --- a/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js
 +++ b/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js
-@@ -139,8 +139,8 @@ set -e
- 
+@@ -170,8 +170,8 @@ set -e
+
  THIS="$0"
  # http://stackoverflow.com/questions/3190818/
 -args=("$@")
 -NUMBER_OF_ARGS="$#"
 +args=("$@" "--ozone-platform=x11")
 +NUMBER_OF_ARGS="\${#args[@]}"
- 
+
  if [ -z "$APPDIR" ] ; then
    # Find the AppDir. It is the directory that contains AppRun.


### PR DESCRIPTION
## Summary

- The `patch-package` patch that injects `--ozone-platform=x11` into the AppImage AppRun script was still named `app-builder-lib+26.8.1.patch`, targeting the old version. `patch-package` skips or misapplies patches when the filename version doesn't match what's installed, so the ozone flag was missing from the built AppImage.
- Renames the patch to `app-builder-lib+26.15.3.patch` (matching the currently installed version) with the equivalent 3-line change.

## Test plan

- [x] `cd main && yarn install` — patch applies without errors
- [x] `cd renderer && yarn make-index-files && yarn build` then `cd ../main && yarn build && yarn package` — AppImage builds and passes the `apprun-patch.test.mjs` assertion