### PR TITLE
Use wss when https

### DIFF
--- a/renderer/src/web/background/IPC.ts
+++ b/renderer/src/web/background/IPC.ts
@@ -17,7 +17,7 @@ class HostTransport {
       this.updateInfo.value = info
     })
     await new Promise((resolve) => {
-      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      const protocol = (window.location.protocol === 'https:') ? 'wss:' : 'ws:'
       this.socket = new Sockette(`${protocol}//${window.location.host}/events`, {
         onmessage: (e) => {
           this.selfDispatch(JSON.parse(e.data))

--- a/renderer/src/web/background/IPC.ts
+++ b/renderer/src/web/background/IPC.ts
@@ -17,7 +17,8 @@ class HostTransport {
       this.updateInfo.value = info
     })
     await new Promise((resolve) => {
-      this.socket = new Sockette(`ws://${window.location.host}/events`, {
+      const protocol = window.location.protocol === 'https:' ? 'wss:' : 'ws:';
+      this.socket = new Sockette(`${protocol}//${window.location.host}/events`, {
         onmessage: (e) => {
           this.selfDispatch(JSON.parse(e.data))
         },


### PR DESCRIPTION
Fixes #1566: Resolves mixed content websocket blocks when accessing the interface over secure proxies or tunnels (for cloud gaming/GeForce NOW purposes).

Updated protocol selection to dynamically switch to `wss:` if the interface is served over `https:`.

Verified locally with a secure Cloudflare tunnel via cloudflared. 