### PR TITLE
fix: update Korean trade site host

### DIFF
--- a/main/src/proxy.ts
+++ b/main/src/proxy.ts
@@ -6,7 +6,7 @@ const PROXY_HOSTS = [
   { host: 'www.pathofexile.com', official: true },
   { host: 'ru.pathofexile.com', official: true },
   { host: 'pathofexile.tw', official: true },
-  { host: 'poe.game.daum.net', official: true },
+  { host: 'poe.kakaogames.com', official: true },
   { host: 'poe.ninja', official: false },
   { host: 'www.poeprices.info', official: false },
 ]

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -92,7 +92,7 @@ export function poeWebApi () {
     case 'en': return 'www.pathofexile.com'
     case 'ru': return 'ru.pathofexile.com'
     case 'cmn-Hant': return 'pathofexile.tw'
-    case 'ko': return 'poe.game.daum.net'
+    case 'ko': return 'poe.kakaogames.com'
   }
 }
 


### PR DESCRIPTION
## Summary

- Update the Korean Path of Exile host from `poe.game.daum.net` to `poe.kakaogames.com`.
- Update the main-process proxy allowlist for the new host.

## Why

Kakao Games moved the Korean site to `poe.kakaogames.com`. The old host now redirects trade POST requests, causing price searches to fail when "Use international site" is disabled.

## Validation

- `npm --prefix renderer run lint`
- `npm --prefix renderer run build`
- `npm --prefix main run build`
- Verified league, item search, fetch, and exchange requests against the Kakao host
- Manually verified in-game item price searches in Korean with "Use international site" disabled