### PR TITLE
Add delay before pasting on linux

### DIFF
--- a/main/src/shortcuts/HostClipboard.ts
+++ b/main/src/shortcuts/HostClipboard.ts
@@ -83,7 +83,7 @@ export class HostClipboard {
 
   // when `shouldRestore` is false, this function continues
   // to work as a throttler for callback
-  restoreShortly (cb: (clipboard: Clipboard) => void) {
+  async restoreShortly (cb: (clipboard: Clipboard) => void | Promise<void>) {
     // Not only do we not overwrite the clipboard, but we don't exec callback.
     // This throttling helps against disconnects from "Too many actions".
     if (!this.isRestored) {
@@ -92,7 +92,7 @@ export class HostClipboard {
 
     this.isRestored = false
     const saved = clipboard.readText()
-    cb(clipboard)
+    await cb(clipboard)
     setTimeout(() => {
       if (this.shouldRestore) {
         clipboard.writeText(saved)

--- a/main/src/shortcuts/text-box.ts
+++ b/main/src/shortcuts/text-box.ts
@@ -12,9 +12,11 @@ const AUTO_CLEAR = [
   '&', // Guild
   '/' // Command
 ]
+const clipboardSettleDelay = () =>
+  process.platform === 'linux' ? new Promise(r => setTimeout(r, 30)) : Promise.resolve()
 
 export function typeInChat (text: string, send: boolean, clipboard: HostClipboard) {
-  clipboard.restoreShortly((clipboard) => {
+  clipboard.restoreShortly(async (clipboard) => {
     const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
 
     if (text.startsWith(PLACEHOLDER_LAST)) {
@@ -37,6 +39,8 @@ export function typeInChat (text: string, send: boolean, clipboard: HostClipboar
       }
     }
 
+    await clipboardSettleDelay()
+
     uIOhook.keyTap(Key.V, modifiers)
 
     if (send) {
@@ -55,9 +59,10 @@ export function stashSearch (
   clipboard: HostClipboard,
   overlay: OverlayWindow
 ) {
-  clipboard.restoreShortly((clipboard) => {
+  clipboard.restoreShortly(async (clipboard) => {
     overlay.assertGameActive()
     clipboard.writeText(text)
+    await clipboardSettleDelay()
     uIOhook.keyTap(Key.F, [Key.Ctrl])
     uIOhook.keyTap(Key.V, [process.platform === 'darwin' ? Key.Meta : Key.Ctrl])
     uIOhook.keyTap(Key.Enter)


### PR DESCRIPTION
There is an issue on Linux where using shortcuts would often paste the previous copied text, not the just copied text. Often this happened when I would use the hotkey to `/exit` then in the vendor use a stash search and it would type `/exit`. The same would happen in reverse, when pasting the search string when trying to `/exit`.

This is seemingly caused by a delay from electron sending the clipboard to the system (in my case KDE Plasma, Arch Linux with kernel `7.1.3-arch2-2`). Adding a small (30ms) delay seems to resolve this issue and causes only a tiny delay before sending the correct text. In my testing this seems to have completely solved the problem.

**This could be a potential problem for Linux users using Awakened PoE Trade to emergency logout in a hurry**. It may require an option to change this value or completely remove it by the user.

This PR was assisted with the help of LLMs. The usage helped with quickly identifying potential problems, writing a fix, and testing. When the solution was discovered, I reviewed the code, and adjusted it to be the least impactful to the existing codebase. I do understand if this is not acceptable for the project.

Note: 30ms was just the first value attempted, there could be a lower value that works better, or it might need to be higher for other users.