### PR TITLE
linux: support native KDE Wayland

### DIFF
--- a/main/build/app-builder-lib+26.9.0.patch
+++ b/main/build/app-builder-lib+26.9.0.patch
@@ -2,13 +2,17 @@ diff --git a/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js b
 index ee817d1..ef1f916 100644
 --- a/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js
 +++ b/node_modules/app-builder-lib/out/targets/appimage/appImageUtil.js
-@@ -139,8 +139,8 @@ set -e
+@@ -139,8 +139,12 @@ set -e
  
  THIS="$0"
  # http://stackoverflow.com/questions/3190818/
 -args=("$@")
 -NUMBER_OF_ARGS="$#"
-+args=("$@" "--ozone-platform=x11")
++if [[ "\${XDG_SESSION_TYPE:-}" == "wayland" && "\${XDG_CURRENT_DESKTOP:-}" == *KDE* ]] ; then
++  args=("$@")
++else
++  args=("$@" "--ozone-platform=x11")
++fi
 +NUMBER_OF_ARGS="\${#args[@]}"
  
  if [ -z "$APPDIR" ] ; then

--- a/main/build/apprun-patch.test.mjs
+++ b/main/build/apprun-patch.test.mjs
@@ -8,11 +8,13 @@ export default function (ctx) {
   const stdout = execSync(`
     chmod +x '${ctx.file}' && \
     '${ctx.file}' --appimage-extract AppRun && \
-    grep 'args=' squashfs-root/AppRun
+    grep -E 'XDG_SESSION_TYPE|args=' squashfs-root/AppRun
   `, { encoding: 'utf-8' })
 
   assert.equal(
     stdout,
-    'args=("$@" "--ozone-platform=x11")\n',
+    'if [[ "${XDG_SESSION_TYPE:-}" == "wayland" && "${XDG_CURRENT_DESKTOP:-}" == *KDE* ]] ; then\n' +
+    '  args=("$@")\n' +
+    '  args=("$@" "--ozone-platform=x11")\n',
     "AppImage contains non patched AppRun file.")
 }

--- a/main/package-lock.json
+++ b/main/package-lock.json
@@ -9,6 +9,7 @@
       "version": "3.28.104",
       "hasInstallScript": true,
       "dependencies": {
+        "@homebridge/dbus-native": "0.7.7",
         "electron-overlay-window": "4.1.0",
         "uiohook-napi": "1.5.5"
       },
@@ -934,6 +935,23 @@
       ],
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@homebridge/dbus-native": {
+      "version": "0.7.7",
+      "resolved": "https://registry.npmjs.org/@homebridge/dbus-native/-/dbus-native-0.7.7.tgz",
+      "integrity": "sha512-VwTSCy1qofS0QLHtOiSVVmtR49xr/DR17D+5VeJm+xw1rGaluv++MF/atF1Jomxsf4WduVed63ouX2s6SH17Qw==",
+      "license": "MIT",
+      "dependencies": {
+        "event-stream": "^4.0.1",
+        "hexy": "^0.4.0",
+        "long": "^5.3.2",
+        "minimist": "^1.2.8",
+        "safe-buffer": "^5.1.2",
+        "xml2js": "^0.6.2"
+      },
+      "bin": {
+        "dbus2js": "bin/dbus2js.js"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -2631,6 +2649,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "license": "MIT"
+    },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
@@ -3119,6 +3143,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/event-stream": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-4.0.1.tgz",
+      "integrity": "sha512-qACXdu/9VHPBzcyhdOWR5/IahhGMf0roTeZJfzz077GwylcDd90yOHLouhmv7GJ5XzPi6ekaQWd8AvPP2nOvpA==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.1",
+        "from": "^0.1.7",
+        "map-stream": "0.0.7",
+        "pause-stream": "^0.0.11",
+        "split": "^1.0.1",
+        "stream-combiner": "^0.2.2",
+        "through": "^2.3.8"
+      }
+    },
     "node_modules/exponential-backoff": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.3.tgz",
@@ -3307,6 +3346,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/from": {
+      "version": "0.1.7",
+      "resolved": "https://registry.npmjs.org/from/-/from-0.1.7.tgz",
+      "integrity": "sha512-twe20eF1OxVxp/ML/kq2p1uc6KvFK/+vs8WjEbeKmV2He22MKm7YF2ANIt+EOqhJ5L3K/SuuPhk0hWQDjOM23g==",
+      "license": "MIT"
     },
     "node_modules/fs-extra": {
       "version": "8.1.0",
@@ -3624,6 +3669,18 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/hexy": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/hexy/-/hexy-0.4.0.tgz",
+      "integrity": "sha512-HxJ6HCV/zrSBeAVRNEhr3CE6yTlCYklMHfCVfJkp7kC+HJqSP1SQ+howWPiHK37t++ELUtgoAoGJut5HyRhIvg==",
+      "license": "MIT",
+      "bin": {
+        "hexy": "bin/hexy_cmd.js"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/hosted-git-info": {
@@ -4083,6 +4140,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/lowercase-keys": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-2.0.0.tgz",
@@ -4127,6 +4190,12 @@
       "engines": {
         "node": "^18.17.0 || >=20.5.0"
       }
+    },
+    "node_modules/map-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/map-stream/-/map-stream-0.0.7.tgz",
+      "integrity": "sha512-C0X0KQmGm3N2ftbTGBhSyuydQ+vV1LC3f3zPvT3RXHXNZrvfPZcoXp/N5DOa8vedX/rTMm2CjTtivFg2STJMRQ==",
+      "license": "MIT"
     },
     "node_modules/matcher": {
       "version": "3.0.0",
@@ -4253,7 +4322,6 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4817,6 +4885,18 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/pause-stream": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
+      "integrity": "sha512-e3FBlXLmN/D1S+zHzanP4E/4Z60oFAa3O051qt1pxa7DEJWKAyil6upYVXCWadEnuoqa4Pkc9oUx9zsxYeRv8A==",
+      "license": [
+        "MIT",
+        "Apache2"
+      ],
+      "dependencies": {
+        "through": "~2.3"
+      }
+    },
     "node_modules/pe-library": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/pe-library/-/pe-library-0.4.1.tgz",
@@ -5115,7 +5195,6 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5153,7 +5232,6 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.6.0.tgz",
       "integrity": "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==",
-      "dev": true,
       "license": "BlueOak-1.0.0",
       "engines": {
         "node": ">=11.0.0"
@@ -5353,6 +5431,18 @@
         "source-map": "^0.6.0"
       }
     },
+    "node_modules/split": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha512-mTyOoPbrivtXnwnIxZRFYRrPNtEFKlpB2fvjSnCQUiAA6qAZzqwna5envK4uk6OIeP17CsdF3rSBGYVBsU0Tkg==",
+      "license": "MIT",
+      "dependencies": {
+        "through": "2"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/sprintf-js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.3.tgz",
@@ -5381,6 +5471,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/stream-combiner": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.2.2.tgz",
+      "integrity": "sha512-6yHMqgLYDzQDcAkL+tjJDC5nSNuNIx0vZtRZeiPh7Saef7VHX9H5Ijn9l2VIol2zaNYlYEX6KyuT/237A58qEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "~0.1.1",
+        "through": "~2.3.4"
       }
     },
     "node_modules/string_decoder": {
@@ -5575,6 +5675,12 @@
       "engines": {
         "node": ">=12.22"
       }
+    },
+    "node_modules/through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg==",
+      "license": "MIT"
     },
     "node_modules/tiny-async-pool": {
       "version": "1.3.0",
@@ -5873,6 +5979,28 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
       }
     },
     "node_modules/xmlbuilder": {

--- a/main/package.json
+++ b/main/package.json
@@ -17,6 +17,7 @@
   },
   "main": "dist/main.js",
   "dependencies": {
+    "@homebridge/dbus-native": "0.7.7",
     "electron-overlay-window": "4.1.0",
     "uiohook-napi": "1.5.5"
   },

--- a/main/src/main.ts
+++ b/main/src/main.ts
@@ -14,9 +14,15 @@ import { AppTray } from './AppTray'
 import { OverlayVisibility } from './windowing/OverlayVisibility'
 import { GameLogWatcher } from './host-files/GameLogWatcher'
 import { HttpProxy } from './proxy'
+import { isPlasmaWayland, WAYLAND_APP_ID } from './wayland'
 
 if (!app.requestSingleInstanceLock()) {
   app.exit()
+}
+
+if (isPlasmaWayland) {
+  app.commandLine.appendSwitch('class', WAYLAND_APP_ID)
+  app.commandLine.appendSwitch('ozone-platform', 'wayland')
 }
 
 if (process.platform !== 'darwin') {
@@ -38,8 +44,15 @@ app.on('ready', async () => {
   setTimeout(
     async () => {
       const overlay = new OverlayWindow(eventPipe, logger, poeWindow)
-      new OverlayVisibility(eventPipe, overlay, gameConfig)
+      if (!isPlasmaWayland) new OverlayVisibility(eventPipe, overlay, gameConfig)
       const shortcuts = await Shortcuts.create(logger, overlay, poeWindow, gameConfig, eventPipe)
+      let isShuttingDown = false
+      app.on('before-quit', (event) => {
+        if (!isPlasmaWayland || isShuttingDown) return
+        event.preventDefault()
+        isShuttingDown = true
+        Promise.all([poeWindow.stop(), shortcuts.stop()]).finally(() => { app.quit() })
+      })
       eventPipe.onEventAnyClient('CLIENT->MAIN::update-host-config', (cfg) => {
         overlay.updateOpts(cfg.overlayKey, cfg.windowTitle)
         shortcuts.updateActions(cfg.shortcuts, cfg.stashScroll, cfg.logKeys, cfg.restoreClipboard, cfg.language)
@@ -48,7 +61,7 @@ app.on('ready', async () => {
         appUpdater.checkAtStartup()
         tray.overlayKey = cfg.overlayKey
       })
-      uIOhook.start()
+      if (!isPlasmaWayland) uIOhook.start()
       const port = await startServer(appUpdater, logger)
       // TODO: move up (currently crashes)
       logger.write(`info ${os.type()} ${os.release} / v${app.getVersion()}`)

--- a/main/src/shortcuts/HostClipboard.ts
+++ b/main/src/shortcuts/HostClipboard.ts
@@ -1,5 +1,6 @@
-import { clipboard, Clipboard } from 'electron'
+import { clipboard } from 'electron'
 import type { Logger } from '../RemoteLogger'
+import { isPlasmaWayland, readWaylandClipboard, writeWaylandClipboard } from '../wayland'
 
 const POLL_DELAY = 48
 const POLL_LIMIT = 500
@@ -27,63 +28,68 @@ export class HostClipboard {
     this.shouldRestore = restoreClipboard
   }
 
-  async readItemText (): Promise<string> {
+  async readItemText (copy: () => void): Promise<string> {
     this.elapsed = 0
     if (this.pollPromise) {
+      copy()
       return await this.pollPromise
     }
 
-    let textBefore = clipboard.readText()
+    let textBefore = await this.readText()
     if (isPoeItem(textBefore)) {
       textBefore = ''
       if (process.platform !== 'linux') {
-        clipboard.writeText('')
+        await this.writeText('')
       } else {
         // workaround KDE's "Prevent empty clipboard" feature
         // see https://github.com/SnosMe/awakened-poe-trade/issues/1790#issuecomment-4062830614
-        clipboard.writeText(`__APT_FORCE_EMPTY_${Date.now()}`)
+        await this.writeText(`__APT_FORCE_EMPTY_${Date.now()}`)
       }
     } else if (process.platform === 'linux') {
       // workaround bug in Proton 10+ https://github.com/SnosMe/awakened-poe-trade/issues/1846
-      clipboard.writeText(`__APT_FORCE_EMPTY_${Date.now()}`)
+      await this.writeText(`__APT_FORCE_EMPTY_${Date.now()}`)
     }
 
     this.pollPromise = new Promise((resolve, reject) => {
-      const poll = () => {
-        const textAfter = clipboard.readText()
+      const poll = async () => {
+        try {
+          const textAfter = await this.readText()
 
-        if (isPoeItem(textAfter)) {
-          if (this.shouldRestore) {
-            clipboard.writeText(textBefore)
-          }
-          this.pollPromise = undefined
-          resolve(textAfter)
-        } else {
-          this.elapsed += POLL_DELAY
-          if (this.elapsed < POLL_LIMIT) {
-            setTimeout(poll, POLL_DELAY)
-          } else {
+          if (isPoeItem(textAfter)) {
             if (this.shouldRestore) {
-              clipboard.writeText(textBefore)
+              await this.writeText(textBefore)
             }
             this.pollPromise = undefined
+            resolve(textAfter)
+          } else {
+            this.elapsed += POLL_DELAY
+            if (this.elapsed < POLL_LIMIT) {
+              setTimeout(() => { void poll() }, POLL_DELAY)
+            } else {
+              if (this.shouldRestore) {
+                await this.writeText(textBefore)
+              }
+              this.pollPromise = undefined
 
-            if (!isPoeItem(textAfter)) {
               this.logger.write('warn [ClipboardPoller] No item text found.')
+              reject(new Error('Reading clipboard timed out'))
             }
-            reject(new Error('Reading clipboard timed out'))
           }
+        } catch (error) {
+          this.pollPromise = undefined
+          reject(error)
         }
       }
-      setTimeout(poll, POLL_DELAY)
+      setTimeout(() => { void poll() }, POLL_DELAY)
     })
 
+    copy()
     return this.pollPromise
   }
 
   // when `shouldRestore` is false, this function continues
   // to work as a throttler for callback
-  restoreShortly (cb: (clipboard: Clipboard) => void) {
+  async restoreShortly (text: string, cb: () => void) {
     // Not only do we not overwrite the clipboard, but we don't exec callback.
     // This throttling helps against disconnects from "Too many actions".
     if (!this.isRestored) {
@@ -91,14 +97,36 @@ export class HostClipboard {
     }
 
     this.isRestored = false
-    const saved = clipboard.readText()
-    cb(clipboard)
-    setTimeout(() => {
-      if (this.shouldRestore) {
-        clipboard.writeText(saved)
-      }
+    let saved: string
+    try {
+      saved = await this.readText()
+      await this.writeText(text)
+      cb()
+    } catch (error) {
       this.isRestored = true
+      this.logger.write(`warn [Clipboard] ${String(error)}`)
+      return
+    }
+    setTimeout(() => {
+      void (async () => {
+        try {
+          if (this.shouldRestore) await this.writeText(saved)
+        } catch (error) {
+          this.logger.write(`warn [Clipboard] ${String(error)}`)
+        } finally {
+          this.isRestored = true
+        }
+      })()
     }, RESTORE_AFTER)
+  }
+
+  private async readText () {
+    return isPlasmaWayland ? await readWaylandClipboard() : clipboard.readText()
+  }
+
+  private async writeText (text: string) {
+    if (isPlasmaWayland) await writeWaylandClipboard(text)
+    else clipboard.writeText(text)
   }
 }
 

--- a/main/src/shortcuts/Shortcuts.ts
+++ b/main/src/shortcuts/Shortcuts.ts
@@ -1,4 +1,4 @@
-import { screen, globalShortcut } from 'electron'
+import { globalShortcut } from 'electron'
 import { uIOhook, UiohookKey, UiohookWheelEvent } from 'uiohook-napi'
 import { isModKey, KeyToElectron, mergeTwoHotkeys } from '../../../ipc/KeyToCode'
 import { typeInChat, stashSearch } from './text-box'
@@ -11,6 +11,7 @@ import type { OverlayWindow } from '../windowing/OverlayWindow'
 import type { GameWindow } from '../windowing/GameWindow'
 import type { GameConfig } from '../host-files/GameConfig'
 import type { ServerEvents } from '../server'
+import { isPlasmaWayland, Keyboard, setWaylandLog, WaylandShortcuts } from '../wayland'
 
 type UiohookKeyT = keyof typeof UiohookKey
 const UiohookToName = Object.fromEntries(Object.entries(UiohookKey).map(([k, v]) => ([v, k])))
@@ -21,6 +22,8 @@ export class Shortcuts {
   private logKeys = false
   private areaTracker: WidgetAreaTracker
   private clipboard: HostClipboard
+  private keyboard = new Keyboard()
+  private waylandShortcuts = isPlasmaWayland ? new WaylandShortcuts() : undefined
 
   static async create (
     logger: Logger,
@@ -31,6 +34,7 @@ export class Shortcuts {
   ) {
     const ocrWorker = await OcrWorker.create()
     const shortcuts = new Shortcuts(logger, overlay, poeWindow, gameConfig, server, ocrWorker)
+    await shortcuts.keyboard.start()
     return shortcuts
   }
 
@@ -42,7 +46,8 @@ export class Shortcuts {
     private server: ServerEvents,
     private ocrWorker: OcrWorker
   ) {
-    this.areaTracker = new WidgetAreaTracker(server, overlay)
+    setWaylandLog((message) => { this.logger.write(message) })
+    this.areaTracker = new WidgetAreaTracker(server, overlay, poeWindow)
     this.clipboard = new HostClipboard(logger)
 
     this.poeWindow.on('active-change', (isActive) => {
@@ -59,7 +64,7 @@ export class Shortcuts {
 
     this.server.onEventAnyClient('CLIENT->MAIN::user-action', (e) => {
       if (e.action === 'stash-search') {
-        stashSearch(e.text, this.clipboard, this.overlay)
+        stashSearch(e.text, this.clipboard, this.overlay, this.keyboard)
       }
     })
 
@@ -78,9 +83,9 @@ export class Shortcuts {
 
       if (!isStashArea(e, this.poeWindow)) {
         if (e.rotation > 0) {
-          uIOhook.keyTap(UiohookKey.ArrowRight)
+          this.keyboard.keyTap(UiohookKey.ArrowRight)
         } else if (e.rotation < 0) {
-          uIOhook.keyTap(UiohookKey.ArrowLeft)
+          this.keyboard.keyTap(UiohookKey.ArrowLeft)
         }
       }
     })
@@ -134,40 +139,50 @@ export class Shortcuts {
     this.actions = actions.filter(action =>
       !duplicates.has(action.shortcut) ||
       action.action.type === 'toggle-overlay')
+
+    if (this.waylandShortcuts && this.poeWindow.isActive) this.register()
   }
 
   private register () {
+    const definitions = []
     for (const entry of this.actions) {
-      const isOk = globalShortcut.register(shortcutToElectron(entry.shortcut), () => {
+      const activate = (releaseKeys: boolean) => {
         if (this.logKeys) {
           this.logger.write(`debug [Shortcuts] Action type: ${entry.action.type}`)
         }
 
-        if (entry.keepModKeys) {
-          const nonModKey = entry.shortcut.split(' + ').filter(key => !isModKey(key))[0]
-          uIOhook.keyToggle(UiohookKey[nonModKey as UiohookKeyT], 'up')
-        } else {
-          entry.shortcut.split(' + ').reverse().forEach(key => { uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], 'up') })
+        if (releaseKeys) {
+          if (entry.keepModKeys) {
+            const nonModKey = entry.shortcut.split(' + ').filter(key => !isModKey(key))[0]
+            this.keyboard.keyToggle(UiohookKey[nonModKey as UiohookKeyT], 'up')
+          } else {
+            entry.shortcut.split(' + ').reverse().forEach(key => { this.keyboard.keyToggle(UiohookKey[key as UiohookKeyT], 'up') })
+          }
         }
 
         if (entry.action.type === 'toggle-overlay') {
           this.areaTracker.removeListeners()
           this.overlay.toggleActiveState()
         } else if (entry.action.type === 'paste-in-chat') {
-          typeInChat(entry.action.text, entry.action.send, this.clipboard)
+          typeInChat(entry.action.text, entry.action.send, this.clipboard, this.keyboard)
         } else if (entry.action.type === 'trigger-event') {
           this.server.sendEventTo('broadcast', {
             name: 'MAIN->CLIENT::widget-action',
             payload: { target: entry.action.target }
           })
         } else if (entry.action.type === 'stash-search') {
-          stashSearch(entry.action.text, this.clipboard, this.overlay)
+          stashSearch(entry.action.text, this.clipboard, this.overlay, this.keyboard)
         } else if (entry.action.type === 'copy-item') {
           const { action } = entry
+          const pressPosition = this.poeWindow.cursorPosition
 
-          const pressPosition = screen.getCursorScreenPoint()
-
-          this.clipboard.readItemText()
+          this.clipboard.readItemText(() => {
+            pressKeysToCopyItemText(
+              (entry.keepModKeys) ? entry.shortcut.split(' + ').filter(key => isModKey(key)) : undefined,
+              this.gameConfig.showModsKey,
+              this.keyboard
+            )
+          })
             .then(clipboard => {
               this.areaTracker.removeListeners()
               this.server.sendEventTo('last-active', {
@@ -179,10 +194,6 @@ export class Shortcuts {
               }
             }).catch(() => {})
 
-          pressKeysToCopyItemText(
-            (entry.keepModKeys) ? entry.shortcut.split(' + ').filter(key => isModKey(key)) : undefined,
-            this.gameConfig.showModsKey
-          )
         } else if (entry.action.type === 'ocr-text' && entry.action.target === 'heist-gems') {
           if (process.platform !== 'win32') return
 
@@ -205,24 +216,50 @@ export class Shortcuts {
             })
           }).catch(() => {})
         }
-      })
+      }
 
+      if (this.waylandShortcuts) {
+        definitions.push({
+          shortcut: entry.shortcut,
+          description: shortcutDescription(entry),
+          onActivated: () => { if (this.poeWindow.isActive) activate(false) }
+        })
+        continue
+      }
+
+      const isOk = globalShortcut.register(shortcutToElectron(entry.shortcut), () => { activate(true) })
       if (!isOk) {
         this.logger.write(`error [Shortcuts] Failed to register a shortcut "${entry.shortcut}". It is already registered by another application.`)
       }
-
       if (entry.action.type === 'test-only') {
         globalShortcut.unregister(shortcutToElectron(entry.shortcut))
       }
     }
+
+    if (this.waylandShortcuts) {
+      void this.waylandShortcuts.configure(definitions)
+      void this.waylandShortcuts.start()
+    }
   }
 
   private unregister () {
-    globalShortcut.unregisterAll()
+    if (this.waylandShortcuts) void this.waylandShortcuts.stop()
+    else globalShortcut.unregisterAll()
+  }
+
+  async stop () {
+    await Promise.all([this.keyboard.stop(), this.waylandShortcuts?.stop()])
   }
 }
 
-function pressKeysToCopyItemText (pressedModKeys: string[] = [], showModsKey: string) {
+function shortcutDescription (entry: ShortcutAction) {
+  const description = entry.action.type === 'copy-item' && entry.action.focusOverlay
+    ? 'price check item'
+    : entry.action.type.replaceAll('-', ' ')
+  return description[0].toUpperCase() + description.slice(1)
+}
+
+function pressKeysToCopyItemText (pressedModKeys: string[] = [], showModsKey: string, keyboard: Keyboard) {
   let keys = mergeTwoHotkeys('Ctrl + C', showModsKey).split(' + ')
   keys = keys.filter(key => key !== 'C')
   if (process.platform !== 'darwin') {
@@ -236,15 +273,15 @@ function pressKeysToCopyItemText (pressedModKeys: string[] = [], showModsKey: st
   }
 
   for (const key of keys) {
-    uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], 'down')
+    keyboard.keyToggle(UiohookKey[key as UiohookKeyT], 'down')
   }
 
   // finally press `C` to copy text
-  uIOhook.keyTap(UiohookKey.C)
+  keyboard.keyTap(UiohookKey.C)
 
   keys.reverse()
   for (const key of keys) {
-    uIOhook.keyToggle(UiohookKey[key as UiohookKeyT], 'up')
+    keyboard.keyToggle(UiohookKey[key as UiohookKeyT], 'up')
   }
 }
 

--- a/main/src/shortcuts/text-box.ts
+++ b/main/src/shortcuts/text-box.ts
@@ -1,7 +1,8 @@
-import { uIOhook, UiohookKey as Key } from 'uiohook-napi'
+import { UiohookKey as Key } from 'uiohook-napi'
 import process from 'process';
 import type { HostClipboard } from './HostClipboard'
 import type { OverlayWindow } from '../windowing/OverlayWindow'
+import type { Keyboard } from '../wayland'
 
 const PLACEHOLDER_LAST = '@last'
 const AUTO_CLEAR = [
@@ -13,30 +14,32 @@ const AUTO_CLEAR = [
   '/' // Command
 ]
 
-export function typeInChat (text: string, send: boolean, clipboard: HostClipboard) {
-  clipboard.restoreShortly((clipboard) => {
-    const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
+export function typeInChat (text: string, send: boolean, clipboard: HostClipboard, uIOhook: Keyboard) {
+  const modifiers = process.platform === 'darwin' ? [Key.Meta] : [Key.Ctrl]
+  const startsWithLast = text.startsWith(PLACEHOLDER_LAST)
+  const endsWithLast = text.endsWith(PLACEHOLDER_LAST)
 
-    if (text.startsWith(PLACEHOLDER_LAST)) {
-      text = text.slice(`${PLACEHOLDER_LAST} `.length)
-      clipboard.writeText(text)
+  if (startsWithLast) {
+    text = text.slice(`${PLACEHOLDER_LAST} `.length)
+  } else if (endsWithLast) {
+    text = text.slice(0, -PLACEHOLDER_LAST.length)
+  }
+
+  void clipboard.restoreShortly(text, () => {
+    if (startsWithLast) {
       uIOhook.keyTap(Key.Enter, modifiers)
-    } else if (text.endsWith(PLACEHOLDER_LAST)) {
-      text = text.slice(0, -PLACEHOLDER_LAST.length)
-      clipboard.writeText(text)
+    } else if (endsWithLast) {
       uIOhook.keyTap(Key.Enter, modifiers)
       uIOhook.keyTap(Key.Home)
       // press twice to focus input when using controller
       uIOhook.keyTap(Key.Home)
       uIOhook.keyTap(Key.Delete)
     } else {
-      clipboard.writeText(text)
       uIOhook.keyTap(Key.Enter)
       if (!AUTO_CLEAR.includes(text[0])) {
         uIOhook.keyTap(Key.A, modifiers)
       }
     }
-
     uIOhook.keyTap(Key.V, modifiers)
 
     if (send) {
@@ -53,11 +56,11 @@ export function typeInChat (text: string, send: boolean, clipboard: HostClipboar
 export function stashSearch (
   text: string,
   clipboard: HostClipboard,
-  overlay: OverlayWindow
+  overlay: OverlayWindow,
+  uIOhook: Keyboard
 ) {
-  clipboard.restoreShortly((clipboard) => {
+  void clipboard.restoreShortly(text, () => {
     overlay.assertGameActive()
-    clipboard.writeText(text)
     uIOhook.keyTap(Key.F, [Key.Ctrl])
     uIOhook.keyTap(Key.V, [process.platform === 'darwin' ? Key.Meta : Key.Ctrl])
     uIOhook.keyTap(Key.Enter)

--- a/main/src/wayland.ts
+++ b/main/src/wayland.ts
@@ -1,0 +1,629 @@
+import { app, type BrowserWindow, type Point, type Rectangle } from 'electron'
+import { EventEmitter } from 'node:events'
+import { mkdir, rm, writeFile, unlink } from 'node:fs/promises'
+import path from 'node:path'
+import { setTimeout as delay } from 'node:timers/promises'
+import * as dbusNative from '@homebridge/dbus-native'
+import { uIOhook, UiohookKey } from 'uiohook-napi'
+
+export const isPlasmaWayland = process.platform === 'linux' &&
+  process.env.XDG_SESSION_TYPE === 'wayland' &&
+  (process.env.XDG_CURRENT_DESKTOP ?? '').toLowerCase().includes('kde')
+
+export const WAYLAND_APP_ID = 'awakened-poe-trade'
+export const WAYLAND_WINDOW_TITLE = 'Awakened PoE Trade'
+
+let writeLog = (_message: string) => {}
+
+export function setWaylandLog (write: (message: string) => void) { writeLog = write }
+
+type DBusError = { name?: string, message?: string }
+type DBusCall = [
+  destination: string, path: string, interfaceName: string, member: string,
+  signature?: string, body?: unknown[]
+]
+type SessionBus = dbusNative.MessageBus & {
+  name?: string
+  signals: EventEmitter
+  mangle: (path: string, iface: string, member: string) => string
+  addMatch: (rule: string, cb: (error?: DBusError) => void) => void
+  exportInterface: (obj: object, path: string, iface: object) => void
+}
+
+let sessionBus: Promise<SessionBus> | undefined
+let portalRequestId = 0
+
+function getSessionBus () {
+  sessionBus ??= (async () => {
+    const bus = (dbusNative as typeof dbusNative & { sessionBus: () => SessionBus }).sessionBus()
+    bus.connection.on('error', () => {})
+
+    for (let tries = 0; !bus.name && tries < 500; ++tries) await delay(10)
+    if (!bus.name) throw new Error('Timed out connecting to the session bus')
+    await invoke(bus, 'org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop',
+      'org.freedesktop.host.portal.Registry', 'Register', 'sa{sv}', [WAYLAND_APP_ID, []]
+    ).catch(() => {})
+    await Promise.all([
+      addMatch(bus, "type='signal',interface='org.freedesktop.portal.Request',member='Response'"),
+      addMatch(bus, "type='signal',interface='org.freedesktop.portal.GlobalShortcuts'")
+    ])
+    return bus
+  })()
+  return sessionBus
+}
+
+function invoke (bus: SessionBus, ...call: DBusCall): Promise<unknown[]> {
+  const [destination, path, interfaceName, member, signature, body] = call
+  return new Promise((resolve, reject) => {
+    bus.invoke({ destination, path, interface: interfaceName, member, signature, body }, ((error: DBusError | undefined, ...body: unknown[]) => {
+      if (error) reject(new Error(`${error.name ?? 'D-Bus error'}: ${error.message ?? ''}`))
+      else resolve(body)
+    }) as never)
+  })
+}
+
+function addMatch (bus: SessionBus, rule: string) {
+  return new Promise<void>((resolve, reject) => {
+    bus.addMatch(rule, (error) => {
+      if (error) reject(new Error(`${error.name ?? 'D-Bus error'}: ${error.message ?? ''}`))
+      else resolve()
+    })
+  })
+}
+
+async function portalRequest (
+  bus: SessionBus, iface: 'RemoteDesktop' | 'GlobalShortcuts', member: string,
+  signature: string, body: unknown[], extraOptions: unknown[] = []
+): Promise<unknown[]> {
+  const token = `awakened_poe_trade_${process.pid}_${++portalRequestId}`
+  const sender = bus.name!.slice(1).replaceAll('.', '_')
+  const requestPath = `/org/freedesktop/portal/desktop/request/${sender}/${token}`
+  const signal = bus.mangle(requestPath, 'org.freedesktop.portal.Request', 'Response')
+  const response = new Promise<unknown[]>(resolve => { bus.signals.once(signal, resolve) })
+  const options = [['handle_token', ['s', token]], ...extraOptions]
+
+  await invoke(bus, 'org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop',
+    `org.freedesktop.portal.${iface}`, member, signature, [...body, options])
+
+  const [result, values] = await response
+  if (result !== 0) throw new Error(`${member} rejected with response ${result as number}`)
+  return values as unknown[]
+}
+
+type KWinState = {
+  target: null | { id: string, active: boolean, bounds: Rectangle }
+  overlay: null | { id: string, active: boolean }
+}
+
+export class WaylandWindowTracker {
+  bounds: Rectangle = { x: 0, y: 0, width: 0, height: 0 }
+  cursorPosition: Point = { x: 0, y: 0 }
+
+  private readonly pluginName = 'awakened-poe-trade-wayland'
+  private readonly scriptPath = path.join(app.getPath('temp'), `${this.pluginName}-${process.pid}.js`)
+  private readonly effectName = 'awakened-poe-trade-overlay'
+  private readonly effectPath = path.join(
+    process.env.XDG_DATA_HOME ?? path.join(app.getPath('home'), '.local', 'share'),
+    'kwin', 'effects', this.effectName
+  )
+  private bus?: SessionBus
+  private window?: BrowserWindow
+  private targetId?: string
+  private overlayId?: string
+  private isAttached = false
+  private isShown = false
+  private restoreFocus: 'none' | 'pending' | 'requested' = 'none'
+  private hideTimer?: NodeJS.Timeout
+  private showTimes: number[] = []
+  private suspended = false
+
+  constructor (
+    private onAttach: () => void, private onActiveChange: (active: boolean) => void,
+    private onPointerMove: (position: Point, modifiers: number) => void
+  ) {}
+
+  async start (window: BrowserWindow | undefined, targetTitle: string) {
+    if (!window) return
+    this.window = window
+
+    try {
+      this.bus = await getSessionBus()
+      this.bus.exportInterface({
+        Update: (state: string) => this.update(JSON.parse(state) as KWinState),
+        Pointer: (x: number, y: number, modifiers: number) => {
+          this.cursorPosition = { x, y }
+          this.onPointerMove(this.cursorPosition, modifiers)
+        }
+      }, '/org/awakened_poe_trade/Wayland', {
+        name: 'org.awakened_poe_trade.Wayland',
+        methods: { Update: ['s', 'b'], Pointer: ['iiu', ''] },
+        properties: {}, signals: {}
+      })
+
+      await this.loadEffect().catch(error => {
+        writeLog(`error [Wayland] Overlay elevation failed: ${String(error)}`)
+      })
+
+      await invoke(this.bus, 'org.kde.KWin', '/Scripting',
+        'org.kde.kwin.Scripting', 'unloadScript', 's', [this.pluginName])
+
+      await writeFile(this.scriptPath, kwinScript(
+        this.bus.name!, targetTitle, process.pid, this.effectName, WAYLAND_WINDOW_TITLE))
+      const [scriptId] = await invoke(this.bus, 'org.kde.KWin', '/Scripting',
+        'org.kde.kwin.Scripting', 'loadScript', 'ss', [this.scriptPath, this.pluginName])
+      await invoke(this.bus, 'org.kde.KWin', `/Scripting/Script${scriptId as number}`,
+        'org.kde.kwin.Script', 'run')
+      await unlink(this.scriptPath).catch(() => {})
+    } catch (error) {
+      writeLog(`error [Wayland] Window tracking failed: ${String(error)}`)
+    }
+  }
+
+  activateOverlay () {
+    this.window?.setIgnoreMouseEvents(false)
+    this.activate(this.overlayId)
+  }
+
+  focusTarget () {
+    this.window?.setIgnoreMouseEvents(true)
+    this.activate(this.targetId)
+  }
+
+  async stop () {
+    if (this.hideTimer) clearTimeout(this.hideTimer)
+    await unlink(this.scriptPath).catch(() => {})
+    if (!this.bus) return
+    await Promise.all([
+      invoke(this.bus, 'org.kde.KWin', '/Scripting',
+        'org.kde.kwin.Scripting', 'unloadScript', 's', [this.pluginName]).catch(() => {}),
+      this.unloadEffect()
+    ])
+  }
+
+  private update (state: KWinState) {
+    this.targetId = state.target?.id
+    this.overlayId = state.overlay?.id
+    if (state.target?.active || state.overlay?.active) {
+      if (this.hideTimer) clearTimeout(this.hideTimer)
+      this.hideTimer = undefined
+    }
+
+    if (!state.target) {
+      if (this.hideTimer) clearTimeout(this.hideTimer)
+      this.hideTimer = undefined
+      if (this.isShown) this.window?.hide()
+      this.isShown = false
+      this.restoreFocus = 'none'
+      this.isAttached = false
+      this.onActiveChange(false)
+      return false
+    }
+
+    this.bounds = state.target.bounds
+    if (!this.isAttached) {
+      this.isAttached = true
+      this.window?.setBounds(this.bounds)
+      this.window?.setIgnoreMouseEvents(true)
+      this.onAttach()
+    }
+
+    if (state.target.active && !this.isShown) {
+      if (this.suspended) return false
+      const now = Date.now()
+      this.showTimes = this.showTimes.filter(time => time > now - 1000)
+      if (this.showTimes.length >= 3) {
+        this.suspended = true
+        writeLog('error [Wayland] Overlay remapping too quickly; window tracking suspended.')
+        this.onActiveChange(false)
+        return false
+      }
+      this.showTimes.push(now)
+      this.isShown = true
+      this.restoreFocus = 'pending'
+      this.window?.showInactive()
+      this.onActiveChange(true)
+      return false
+    }
+
+    if (this.restoreFocus !== 'none') {
+      if (this.restoreFocus === 'requested' && state.target.active) {
+        this.restoreFocus = 'none'
+      } else if (this.restoreFocus === 'pending' && state.overlay?.active) {
+        this.restoreFocus = 'requested'
+        this.activate(this.targetId)
+        return false
+      } else return false
+    }
+
+    if (!state.overlay?.active) this.window?.setIgnoreMouseEvents(true)
+    if (!state.target.active && !state.overlay?.active && this.isShown && !this.hideTimer) {
+      this.hideTimer = setTimeout(() => {
+        this.hideTimer = undefined
+        if (this.isShown) {
+          this.isShown = false
+          this.window?.hide()
+        }
+      }, 200)
+    }
+    this.onActiveChange(state.target.active)
+    return state.target.active || Boolean(state.overlay?.active) || this.isShown
+  }
+
+  private activate (id?: string) {
+    if (!id || !this.bus) return
+    invoke(this.bus, 'org.kde.KWin', '/WindowsRunner',
+      'org.kde.krunner1', 'Run', 'ss', [`0_${id}`, '']).catch(error => {
+      writeLog(`error [Wayland] Window activation failed: ${String(error)}`)
+    })
+  }
+
+  private async loadEffect () {
+    if (!this.bus) return
+    await invoke(this.bus, 'org.kde.KWin', '/Effects',
+      'org.kde.kwin.Effects', 'unloadEffect', 's', [this.effectName]).catch(() => {})
+    const codePath = path.join(this.effectPath, 'contents', 'code')
+    await mkdir(codePath, { recursive: true })
+    await Promise.all([
+      writeFile(path.join(this.effectPath, 'metadata.json'), kwinEffectMetadata(this.effectName)),
+      writeFile(path.join(codePath, 'main.js'), kwinEffect(process.pid, WAYLAND_WINDOW_TITLE))
+    ])
+    const [loaded] = await invoke(this.bus, 'org.kde.KWin', '/Effects',
+      'org.kde.kwin.Effects', 'loadEffect', 's', [this.effectName])
+    if (!loaded) throw new Error('KWin rejected the overlay effect')
+  }
+
+  private async unloadEffect () {
+    if (this.bus) await invoke(this.bus, 'org.kde.KWin', '/Effects',
+      'org.kde.kwin.Effects', 'unloadEffect', 's', [this.effectName]).catch(() => {})
+    await rm(this.effectPath, { recursive: true, force: true }).catch(() => {})
+  }
+}
+
+export class Keyboard {
+  private bus?: SessionBus
+  private session?: string
+  private inputOperations = Promise.resolve()
+  private pressedKeys = new Set<number>()
+
+  async start () {
+    if (!isPlasmaWayland) return
+
+    try {
+      this.bus = await getSessionBus()
+      const created = await portalRequest(this.bus, 'RemoteDesktop', 'CreateSession', 'a{sv}', [], [
+        ['session_handle_token', ['s', `awakened_poe_trade_${process.pid}`]]
+      ])
+      this.session = variantValue(created, 'session_handle') as string
+      await portalRequest(this.bus, 'RemoteDesktop', 'SelectDevices', 'oa{sv}', [this.session], [
+        ['types', ['u', 1]]
+      ])
+      await portalRequest(this.bus, 'RemoteDesktop', 'Start', 'osa{sv}', [this.session, ''])
+    } catch (error) {
+      writeLog(`error [Wayland] Keyboard access failed: ${String(error)}`)
+    }
+  }
+
+  keyTap (key: number, modifiers: number[] = []) {
+    if (!isPlasmaWayland) return uIOhook.keyTap(key, modifiers)
+    for (const modifier of modifiers) this.keyToggle(modifier, 'down')
+    this.keyToggle(key, 'down')
+    this.keyToggle(key, 'up')
+    for (const modifier of [...modifiers].reverse()) this.keyToggle(modifier, 'up')
+  }
+
+  keyToggle (key: number, state: 'down' | 'up') {
+    if (!isPlasmaWayland) return uIOhook.keyToggle(key, state)
+    if (!this.bus || !this.session) return
+
+    const bus = this.bus
+    const session = this.session
+    this.inputOperations = this.inputOperations.then(async () => {
+      try {
+        await notifyKeyboardKeycode(bus, session, key, state)
+        if (state === 'down') this.pressedKeys.add(key)
+        else this.pressedKeys.delete(key)
+      } catch (error) {
+        writeLog(`error [Wayland] Keyboard input failed: ${String(error)}`)
+      }
+    })
+  }
+
+  async stop () {
+    if (!this.bus || !this.session) return
+    const bus = this.bus
+    const session = this.session
+    this.session = undefined
+    this.inputOperations = this.inputOperations.then(async () => {
+      for (const key of this.pressedKeys)
+        await notifyKeyboardKeycode(bus, session, key, 'up').catch(() => {})
+      this.pressedKeys.clear()
+    })
+    await this.inputOperations
+    await invoke(bus, 'org.freedesktop.portal.Desktop', session,
+      'org.freedesktop.portal.Session', 'Close').catch(() => {})
+  }
+}
+
+function notifyKeyboardKeycode (
+  bus: SessionBus, session: string, key: number, state: 'down' | 'up'
+) {
+  return invoke(bus, 'org.freedesktop.portal.Desktop', '/org/freedesktop/portal/desktop',
+    'org.freedesktop.portal.RemoteDesktop', 'NotifyKeyboardKeycode', 'oa{sv}iu',
+    [session, [], toEvdev(key), state === 'down' ? 1 : 0])
+}
+
+export async function readWaylandClipboard () {
+  const bus = await getSessionBus()
+  const [text = ''] = await invoke(bus, 'org.kde.klipper', '/klipper',
+    'org.kde.klipper.klipper', 'getClipboardContents')
+  return text as string
+}
+
+export async function writeWaylandClipboard (text: string) {
+  const bus = await getSessionBus()
+  await invoke(bus, 'org.kde.klipper', '/klipper',
+    'org.kde.klipper.klipper', 'setClipboardContents', 's', [text])
+}
+
+export type WaylandShortcut = { shortcut: string, description: string, onActivated: () => void }
+
+export class WaylandShortcuts {
+  private bus?: SessionBus
+  private session?: string
+  private shortcuts: Array<WaylandShortcut & { id: string }> = []
+  private enabled = false
+  private operations = Promise.resolve()
+  private readonly activated = (body: unknown[]) => {
+    const [session, id] = body as [string, string]
+    if (session === this.session) this.shortcuts.find(shortcut => shortcut.id === id)?.onActivated()
+  }
+
+  configure (shortcuts: WaylandShortcut[]) {
+    const next = shortcuts.map((shortcut, index) => ({
+      ...shortcut,
+      id: `action_${index}_${shortcut.shortcut.replaceAll(/[^A-Za-z0-9]/g, '_')}`
+    }))
+    this.operations = this.operations.then(async () => {
+      await this.close()
+      this.shortcuts = next
+      if (this.enabled) await this.open()
+    })
+    return this.operations
+  }
+
+  start () {
+    this.enabled = true
+    this.operations = this.operations.then(() => this.enabled ? this.open() : undefined)
+    return this.operations
+  }
+
+  stop () {
+    this.enabled = false
+    this.operations = this.operations.then(() => this.close())
+    return this.operations
+  }
+
+  private async open () {
+    if (!isPlasmaWayland || this.session || this.shortcuts.length === 0) return
+
+    try {
+      this.bus = await getSessionBus()
+      const created = await portalRequest(this.bus, 'GlobalShortcuts', 'CreateSession', 'a{sv}', [], [
+        ['session_handle_token', ['s', `awakened_poe_trade_shortcuts_${process.pid}_${++portalRequestId}`]]
+      ])
+      this.session = variantValue(created, 'session_handle') as string
+
+      const activatedSignal = shortcutSignal(this.bus)
+      this.bus.signals.on(activatedSignal, this.activated)
+
+      const definitions = this.shortcuts.map(shortcut => [shortcut.id, [
+        ['description', ['s', shortcut.description]],
+        ['preferred_trigger', ['s', toPortalTrigger(shortcut.shortcut)]]
+      ]])
+      const listed = await portalRequest(
+        this.bus, 'GlobalShortcuts', 'ListShortcuts', 'oa{sv}', [this.session]
+      )
+      const existing = variantValue(listed, 'shortcuts') as unknown[]
+      const existingIds = new Set(existing.map(shortcut => (shortcut as unknown[])[0] as string))
+      if (!this.shortcuts.every(shortcut => existingIds.has(shortcut.id))) {
+        await portalRequest(this.bus, 'GlobalShortcuts', 'BindShortcuts',
+          'oa(sa{sv})sa{sv}', [this.session, definitions, ''])
+      }
+    } catch (error) {
+      writeLog(`error [Wayland] Global shortcut access failed: ${String(error)}`)
+      await this.close()
+    }
+  }
+
+  private async close () {
+    if (!this.bus || !this.session) return
+    this.bus.signals.off(shortcutSignal(this.bus), this.activated)
+    await invoke(this.bus, 'org.freedesktop.portal.Desktop', this.session,
+      'org.freedesktop.portal.Session', 'Close').catch(() => {})
+    this.session = undefined
+  }
+}
+
+function shortcutSignal (bus: SessionBus) {
+  return bus.mangle('/org/freedesktop/portal/desktop',
+    'org.freedesktop.portal.GlobalShortcuts', 'Activated')
+}
+
+function variantValue (values: unknown[], name: string) {
+  const entry = values.find(value => Array.isArray(value) && value[0] === name) as unknown[] | undefined
+  if (!entry) throw new Error(`Portal response did not contain ${name}`)
+  return (entry[1] as [unknown, unknown[]])[1][0]
+}
+
+function toEvdev (key: number) {
+  const extended: Record<number, number> = {
+    [UiohookKey.PageUp]: 104, [UiohookKey.PageDown]: 109,
+    [UiohookKey.End]: 107, [UiohookKey.Home]: 102,
+    [UiohookKey.ArrowLeft]: 105, [UiohookKey.ArrowUp]: 103,
+    [UiohookKey.ArrowRight]: 106, [UiohookKey.ArrowDown]: 108,
+    [UiohookKey.Insert]: 110, [UiohookKey.Delete]: 111
+  }
+  return extended[key] ?? key
+}
+
+function toPortalTrigger (shortcut: string) {
+  const modifiers: Record<string, string> = { Ctrl: 'CTRL', Alt: 'ALT', Shift: 'SHIFT', Meta: 'LOGO' }
+  const keysyms: Record<string, string> = {
+    Space: 'space', Enter: 'Return', Backspace: 'BackSpace', CapsLock: 'Caps_Lock',
+    PageUp: 'Prior', PageDown: 'Next', ArrowLeft: 'Left', ArrowUp: 'Up',
+    ArrowRight: 'Right', ArrowDown: 'Down', Numpad0: 'KP_0', Numpad1: 'KP_1',
+    Numpad2: 'KP_2', Numpad3: 'KP_3', Numpad4: 'KP_4', Numpad5: 'KP_5',
+    Numpad6: 'KP_6', Numpad7: 'KP_7', Numpad8: 'KP_8', Numpad9: 'KP_9',
+    NumpadMultiply: 'KP_Multiply', NumpadAdd: 'KP_Add', NumpadSubtract: 'KP_Subtract',
+    NumpadDecimal: 'KP_Decimal', NumpadDivide: 'KP_Divide', Semicolon: 'semicolon',
+    Equal: 'equal', Comma: 'comma', Minus: 'minus', Period: 'period', Slash: 'slash',
+    Backquote: 'grave', BracketLeft: 'bracketleft', Backslash: 'backslash',
+    BracketRight: 'bracketright', Quote: 'apostrophe'
+  }
+  return shortcut.split(' + ').map(key =>
+    modifiers[key] ?? keysyms[key] ?? (/^[A-Z]$/.test(key) ? key.toLowerCase() : key)
+  ).join('+')
+}
+
+function kwinScript (
+  busName: string, targetTitle: string, pid: number, effectName: string, overlayTitle: string
+) {
+  return `
+const [busName, targetTitle, overlayPid, effectName, overlayTitle] = ${JSON.stringify([
+    busName, targetTitle, pid, effectName, overlayTitle
+  ])}
+const aptPath = '/org/awakened_poe_trade/Wayland'
+const aptInterface = 'org.awakened_poe_trade.Wayland'
+let target
+let overlay
+let updateSerial = 0, pointerSentAt = 0, pointerSerial = 0, pointerDelivered = 0
+
+function sendPointer (force = false) {
+  if (!target || (!target.active && !(overlay && overlay.active))) return
+  const now = Date.now()
+  if (!force && now - pointerSentAt < 16) return
+  pointerSentAt = now
+  const position = workspace.cursorPos
+  const serial = ++pointerSerial
+  callDBus('org.kde.KWin', '/Effects', 'org.kde.kwin.Effects', 'debug', effectName, '', debug => {
+    if (serial < pointerDelivered) return
+    pointerDelivered = serial
+    const match = /\\n\\s+To: (-?\\d+)/.exec(String(debug))
+    callDBus(busName, aptPath, aptInterface, 'Pointer',
+      position.x, position.y, match ? Number(match[1]) : 0)
+  })
+}
+
+function sendState () {
+  const serial = ++updateSerial
+  const state = {
+    target: target ? { id: target.internalId.toString(), active: target.active,
+      bounds: target.frameGeometry } : null,
+    overlay: overlay ? { id: overlay.internalId.toString(), active: overlay.active } : null
+  }
+  callDBus(busName, aptPath, aptInterface, 'Update', JSON.stringify(state), visible => {
+    if (serial === updateSerial && overlay) overlay.opacity = visible ? 1 : 0.01
+  })
+}
+
+function refresh () {
+  const previousTarget = target
+  const previousOverlay = overlay
+  target = workspace.stackingOrder.find(window => {
+    const appIds = [window.desktopFileName, window.resourceClass, window.resourceName]
+      .map(value => String(value).toLowerCase())
+    return window.caption === targetTitle &&
+      appIds.some(value => value === 'steam_app_238960' || value.startsWith('pathofexile'))
+  })
+  overlay = workspace.stackingOrder.find(window =>
+    window.pid === overlayPid && window.caption === overlayTitle)
+
+  if (target && target !== previousTarget) {
+    const tracked = target
+    tracked.frameGeometryChanged.connect(() => { if (target === tracked) refresh() })
+  }
+  if (overlay) {
+    if (overlay !== previousOverlay) overlay.opacity = 0.01
+    if (target && !sameGeometry(overlay.frameGeometry, target.frameGeometry))
+      overlay.frameGeometry = target.frameGeometry
+    if (!overlay.keepAbove) overlay.keepAbove = true
+    if (!overlay.skipTaskbar) overlay.skipTaskbar = true
+    if (!overlay.skipSwitcher) overlay.skipSwitcher = true
+  }
+  sendState()
+  sendPointer(true)
+}
+
+function watchCaption (window) { window.captionChanged.connect(refresh) }
+function remove (window) {
+  if (window === target) target = undefined
+  if (window === overlay) overlay = undefined
+  sendState()
+}
+function sameGeometry (a, b) {
+  return a.x === b.x && a.y === b.y && a.width === b.width && a.height === b.height
+}
+
+workspace.stackingOrder.forEach(watchCaption)
+workspace.windowAdded.connect(window => { watchCaption(window); refresh() })
+workspace.windowRemoved.connect(remove)
+workspace.windowActivated.connect(refresh)
+workspace.cursorPosChanged.connect(() => sendPointer())
+refresh()
+`
+}
+
+function kwinEffectMetadata (id: string) {
+  return `${JSON.stringify({
+    KPackageStructure: 'KWin/Effect',
+    KPlugin: {
+      EnabledByDefault: false, Id: id, License: 'MIT',
+      Name: 'Awakened PoE Trade Overlay'
+    },
+    'X-Plasma-API': 'javascript'
+  }, null, 2)}\n`
+}
+
+function kwinEffect (pid: number, overlayTitle: string) {
+  return `
+const [overlayPid, overlayTitle] = ${JSON.stringify([pid, overlayTitle])}
+const controlModifier = 0x04000000, altModifier = 0x08000000
+let overlay, modifierAnimation, modifiers = 0
+
+function updateModifierAnimation () {
+  if (modifierAnimation) cancel(modifierAnimation)
+  modifierAnimation = undefined
+  if (overlay && modifiers)
+    modifierAnimation = set({ window: overlay, duration: 1,
+      animations: [{ type: Effect.Generic, to: modifiers }] })
+}
+
+function refresh () {
+  const next = effects.stackingOrder.find(window =>
+    window.pid === overlayPid && window.caption === overlayTitle)
+  if (next === overlay) return
+  if (overlay) effects.setElevatedWindow(overlay, false)
+  overlay = next
+  if (overlay) effects.setElevatedWindow(overlay, true)
+  updateModifierAnimation()
+}
+
+effects.windowAdded.connect(refresh)
+effects.windowClosed.connect(window => {
+  if (window !== overlay) return
+  if (modifierAnimation) cancel(modifierAnimation)
+  modifierAnimation = undefined
+  effects.setElevatedWindow(overlay, false)
+  overlay = undefined
+})
+effects.mouseChanged.connect((position, oldPosition, buttons, oldButtons, nextModifiers) => {
+  const nativeModifiers = Number(nextModifiers)
+  const modifiersNow = (nativeModifiers & controlModifier ? 1 : 0) |
+    (nativeModifiers & altModifier ? 2 : 0)
+  if (modifiers === modifiersNow) return
+  modifiers = modifiersNow
+  updateModifierAnimation()
+})
+refresh()
+`
+}

--- a/main/src/windowing/GameWindow.ts
+++ b/main/src/windowing/GameWindow.ts
@@ -1,6 +1,7 @@
-import type { BrowserWindow } from 'electron'
+import { screen, type BrowserWindow } from 'electron'
 import { EventEmitter } from 'events'
 import { OverlayController, AttachEvent } from 'electron-overlay-window'
+import { isPlasmaWayland, WaylandWindowTracker } from '../wayland'
 
 export interface GameWindow {
   on: (event: 'active-change', listener: (isActive: boolean) => void) => this
@@ -8,8 +9,14 @@ export interface GameWindow {
 export class GameWindow extends EventEmitter {
   private _isActive = false
   private _isTracking = false
+  private _keyboardModifiers = 0
+  private wayland?: WaylandWindowTracker
 
-  get bounds () { return OverlayController.targetBounds }
+  get bounds () { return this.wayland?.bounds ?? OverlayController.targetBounds }
+
+  get cursorPosition () { return this.wayland?.cursorPosition ?? screen.getCursorScreenPoint() }
+
+  get keyboardModifiers () { return this._keyboardModifiers }
 
   get isActive () { return this._isActive }
 
@@ -32,17 +39,44 @@ export class GameWindow extends EventEmitter {
 
   attach (window: BrowserWindow | undefined, title: string) {
     if (!this._isTracking) {
+      this._isTracking = true
+      if (isPlasmaWayland) {
+        this.wayland = new WaylandWindowTracker(
+          () => { this.emit('attach', undefined) },
+          (active) => { this.isActive = active },
+          (position, modifiers) => {
+            this._keyboardModifiers = modifiers
+            this.emit('pointer-move', position, modifiers)
+          }
+        )
+        this.wayland.start(window, title)
+        return
+      }
       OverlayController.events.on('focus', () => { this.isActive = true })
       OverlayController.events.on('blur', () => { this.isActive = false })
       OverlayController.attachByTitle(window, title, { hasTitleBarOnMac: true })
-      this._isTracking = true
     }
   }
 
   onAttach (cb: (hasAccess: boolean | undefined) => void) {
+    if (isPlasmaWayland) return void this.addListener('attach', cb)
     OverlayController.events.on('attach', (e: AttachEvent) => {
       cb(e.hasAccess)
     })
+  }
+
+  activateOverlay () {
+    if (this.wayland) this.wayland.activateOverlay()
+    else OverlayController.activateOverlay()
+  }
+
+  focusTarget () {
+    if (this.wayland) this.wayland.focusTarget()
+    else OverlayController.focusTarget()
+  }
+
+  stop () {
+    return this.wayland?.stop() ?? Promise.resolve()
   }
 
   screenshot () {

--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -1,9 +1,10 @@
 import path from 'path'
 import { BrowserWindow, dialog, shell, Menu, WebContents } from 'electron'
-import { OverlayController, OVERLAY_WINDOW_OPTS } from 'electron-overlay-window'
+import { OVERLAY_WINDOW_OPTS } from 'electron-overlay-window'
 import type { ServerEvents } from '../server'
 import type { Logger } from '../RemoteLogger'
 import type { GameWindow } from './GameWindow'
+import { isPlasmaWayland, WAYLAND_WINDOW_TITLE } from '../wayland'
 
 export class OverlayWindow {
   public isInteractable = false
@@ -30,6 +31,9 @@ export class OverlayWindow {
     this.window = new BrowserWindow({
       icon: path.join(__dirname, process.env.STATIC!, 'icon.png'),
       ...OVERLAY_WINDOW_OPTS,
+      title: isPlasmaWayland ? WAYLAND_WINDOW_TITLE : undefined,
+      skipTaskbar: isPlasmaWayland || OVERLAY_WINDOW_OPTS.skipTaskbar,
+      alwaysOnTop: isPlasmaWayland || OVERLAY_WINDOW_OPTS.alwaysOnTop,
       width: 800,
       height: 600,
       webPreferences: {
@@ -76,7 +80,7 @@ export class OverlayWindow {
   assertOverlayActive = () => {
     if (!this.isInteractable) {
       this.isInteractable = true
-      OverlayController.activateOverlay()
+      this.poeWindow.activateOverlay()
       this.poeWindow.isActive = false
     }
   }
@@ -84,7 +88,7 @@ export class OverlayWindow {
   assertGameActive = () => {
     if (this.isInteractable) {
       this.isInteractable = false
-      OverlayController.focusTarget()
+      this.poeWindow.focusTarget()
       this.poeWindow.isActive = true
     }
   }

--- a/main/src/windowing/WidgetAreaTracker.ts
+++ b/main/src/windowing/WidgetAreaTracker.ts
@@ -1,7 +1,9 @@
 import { Rectangle, Point, screen } from 'electron'
 import { uIOhook, UiohookMouseEvent } from 'uiohook-napi'
 import type { OverlayWindow } from './OverlayWindow'
+import type { GameWindow } from './GameWindow'
 import type { ServerEvents } from '../server'
+import { isPlasmaWayland } from '../wayland'
 
 export class WidgetAreaTracker {
   private holdKey!: string
@@ -11,7 +13,8 @@ export class WidgetAreaTracker {
 
   constructor (
     private server: ServerEvents,
-    private overlay: OverlayWindow
+    private overlay: OverlayWindow,
+    private poeWindow: GameWindow
   ) {
     this.server.onEventAnyClient('OVERLAY->MAIN::track-area', (opts) => {
       this.holdKey = opts.holdKey
@@ -28,24 +31,44 @@ export class WidgetAreaTracker {
       } else {
         this.closeThreshold = opts.closeThreshold
         this.from = opts.from
-        this.area = opts.area
+        this.area = isPlasmaWayland ? {
+          ...opts.area,
+          x: opts.area.x + this.poeWindow.bounds.x,
+          y: opts.area.y + this.poeWindow.bounds.y
+        } : opts.area
       }
 
       this.removeListeners()
+      if (isPlasmaWayland) {
+        this.poeWindow.addListener('pointer-move', this.handleWaylandMouseMove)
+        this.handleWaylandMouseMove(this.poeWindow.cursorPosition, this.poeWindow.keyboardModifiers)
+        return
+      }
       uIOhook.addListener('mousemove', this.handleMouseMove)
       uIOhook.addListener('mousedown', this.handleMouseDown)
     })
   }
 
   removeListeners () {
+    this.poeWindow.removeListener('pointer-move', this.handleWaylandMouseMove)
     uIOhook.removeListener('mousemove', this.handleMouseMove)
     uIOhook.removeListener('mousedown', this.handleMouseDown)
   }
 
   private readonly handleMouseMove = (e: UiohookMouseEvent) => {
     const modifier = e.ctrlKey ? 'Ctrl' : (e.altKey ? 'Alt' : undefined)
-    if (!this.overlay.isInteractable && modifier !== this.holdKey) {
-      const distance = Math.hypot(e.x - this.from.x, e.y - this.from.y)
+    this.handlePointerMove(e, modifier === this.holdKey)
+  }
+
+  private readonly handleWaylandMouseMove = (position: Point, modifiers: number) => {
+    if (!isPlasmaWayland) return
+    const holdModifier = this.holdKey === 'Ctrl' ? 1 : (this.holdKey === 'Alt' ? 2 : 0)
+    this.handlePointerMove(position, (modifiers & holdModifier) !== 0)
+  }
+
+  private handlePointerMove (position: Point, holdKeyActive: boolean) {
+    if (!this.overlay.isInteractable && !holdKeyActive) {
+      const distance = Math.hypot(position.x - this.from.x, position.y - this.from.y)
       if (distance > this.closeThreshold) {
         this.server.sendEventTo('broadcast', {
           name: 'MAIN->OVERLAY::hide-exclusive-widget',
@@ -53,7 +76,7 @@ export class WidgetAreaTracker {
         })
         this.removeListeners()
       }
-    } else if (isPointInsideRect(e, this.area)) {
+    } else if (isPointInsideRect(position, this.area)) {
       this.overlay.assertOverlayActive()
     } else if (this.overlay.isInteractable) {
       this.removeListeners()


### PR DESCRIPTION
Why: Native-Wayland PoE has no X11 window, so the existing overlay doesn't work.
Scope: KDE Plasma Wayland (typical CachyOS config) only, existing X11/XWayland behaviour unchanged

What's in there: my daily-driver patch that I've been using for a while. With 3.29 coming up I figured I'd fork and upstream the changes for you to consider merging, if you want to. Inside:

- KWin integration for PoE window tracking and overlay stacking.
- GlobalShortcuts portal for hotkeys.
- RemoteDesktop portal for synthetic keyboard input.
- Klipper D-Bus integration for clipboard operations.
- Conditional native-Wayland AppImage launch on KDE Wayland.

What it isn't: generic GNOME/Sway/Hyprland Wayland support.

Edit: Narrowed down window targeting further (had a conflict with the Steam settings window !)

Related to: #1647 , probably a couple others. Please feel free to ask questions or make edits directly. As far as I can tell, all behaviours are identical to the X11 version.