### PR TITLE
fix(leagues): handle undefined rules and sync webview cookies for Cloudflare

### DIFF
--- a/main/src/windowing/OverlayWindow.ts
+++ b/main/src/windowing/OverlayWindow.ts
@@ -1,5 +1,5 @@
 import path from 'path'
-import { BrowserWindow, dialog, shell, Menu, WebContents } from 'electron'
+import { BrowserWindow, dialog, shell, Menu, WebContents, session } from 'electron'
 import { OverlayController, OVERLAY_WINDOW_OPTS } from 'electron-overlay-window'
 import type { ServerEvents } from '../server'
 import type { Logger } from '../RemoteLogger'
@@ -48,6 +48,26 @@ export class OverlayWindow {
     this.window.webContents.on('before-input-event', this.handleExtraCommands)
     this.window.webContents.on('did-attach-webview', (_, webviewWebContents) => {
       webviewWebContents.on('before-input-event', this.handleExtraCommands)
+      webviewWebContents.on('did-finish-load', async () => {
+        try {
+          const cookies = await webviewWebContents.session.cookies.get({})
+          for (const cookie of cookies) {
+            const scheme = cookie.secure ? 'https' : 'http'
+            const domain = (cookie.domain || 'pathofexile.com').replace(/^\./, '')
+            const url = `${scheme}://${domain}${cookie.path || '/'}`
+            await session.defaultSession.cookies.set({
+              url,
+              name: cookie.name,
+              value: cookie.value,
+              domain: cookie.domain,
+              path: cookie.path,
+              secure: cookie.secure,
+              httpOnly: cookie.httpOnly,
+              expirationDate: cookie.expirationDate
+            })
+          }
+        } catch {}
+      })
     })
 
     this.window.webContents.setWindowOpenHandler((details) => {

--- a/renderer/src/web/background/Leagues.ts
+++ b/renderer/src/web/background/Leagues.ts
@@ -50,13 +50,35 @@ export const useLeagues = createGlobalState(() => {
     error.value = null
 
     try {
-      const response = await Host.proxy(`${poeWebApi()}/api/leagues?type=main&realm=pc`)
-      if (!response.ok) throw new Error(JSON.stringify(Object.fromEntries(response.headers)))
-      const leagues: ApiLeague[] = await response.json()
+      let leagues: ApiLeague[] | undefined
+      try {
+        const response = await Host.proxy(`${poeWebApi()}/api/leagues?type=main&realm=pc`)
+        if (response.ok) {
+          leagues = await response.json()
+        }
+      } catch {}
+
+      if (!leagues) {
+        /* eslint-disable-next-line @typescript-eslint/no-explicit-any */
+        const webview = document.querySelector<any>('webview')
+        if (webview && typeof webview.executeJavaScript === 'function') {
+          try {
+            const bodyText = await webview.executeJavaScript('document.body.innerText')
+            if (bodyText && bodyText.trim().startsWith('[')) {
+              leagues = JSON.parse(bodyText)
+            }
+          } catch {}
+        }
+      }
+
+      if (!leagues) {
+        throw new Error('Failed to load leagues.')
+      }
+
       tradeLeagues.value = leagues
         .filter(league =>
           !PERMANENT_HC.includes(league.id) &&
-          !league.rules.some(rule => rule.id === 'NoParties' ||
+          !league.rules?.some(rule => rule.id === 'NoParties' ||
             (rule.id === 'HardMode' && !league.event)))
         .map(league => {
           return { id: league.id, isPopular: true }

--- a/renderer/src/web/price-check/BackgroundInfo.vue
+++ b/renderer/src/web/price-check/BackgroundInfo.vue
@@ -8,6 +8,7 @@
   <ui-error-box class="mx-4 mt-4" v-else-if="leagues.error.value">
     <template #name>{{ t('app.leagues_failed') }}</template>
     <p>{{ t('app.leagues_failed_help') }}</p>
+    <p class="text-xs text-red-400 font-mono mt-1 break-all" v-if="leagues.error.value">{{ leagues.error.value }}</p>
     <template #actions>
       <button class="btn" @click="leagues.load">{{ t('Retry') }}</button>
       <button class="btn" @click="openCaptcha">{{ t('Browser') }}</button>


### PR DESCRIPTION
Fixes #1840

### Summary of Changes

1. **Safely handle optional rules array on API leagues**:
   - In Leagues.ts, league.rules can be undefined for standard/main leagues in the PoE API response.
   - Using league.rules?.some(...) prevents an unhandled TypeError: Cannot read properties of undefined (reading 'some') from crashing the load() function.

2. **Webview Cookie Synchronization for Cloudflare CAPTCHAs**:
   - In OverlayWindow.ts, added a did-finish-load listener to the webview's WebContents.
   - When users complete a Cloudflare CAPTCHA in the built-in browser webview, cookies (including cf_clearance) are automatically synchronized from webviewWebContents.session to session.defaultSession.cookies.
   - This ensures background proxy requests (net.request) share clearance credentials.

3. **Fallback DOM Parser for Leagues**:
   - In Leagues.ts, added a fallback that reads inner text from the webview element if background requests fail.

4. **Error Display in BackgroundInfo**:
   - Render leagues.error.value inside BackgroundInfo.vue for better error visibility.