### PR TITLE
Fix: magic items price check failed in chinese

### DIFF
--- a/renderer/src/parser/magic-name.ts
+++ b/renderer/src/parser/magic-name.ts
@@ -1,10 +1,9 @@
 import { ITEM_BY_TRANSLATED } from '@/assets/data'
 
 export function magicBasetype (name: string) {
-  // Chinese/Korean names have no spaces to split on, so fall back to characters
-  const hasSpaces = name.includes(' ')
-  const words = hasSpaces ? name.split(' ') : [...name]
-  const separator = hasSpaces ? ' ' : ''
+  // Chinese and Japanese don't use spaces to separate words, so fallback to characters
+  const separator = name.includes(' ') ? ' ' : ''
+  const words = name.split(separator)
 
   const perm: string[] = words.flatMap((_, start) =>
     Array(words.length - start).fill(undefined)

--- a/renderer/src/parser/magic-name.ts
+++ b/renderer/src/parser/magic-name.ts
@@ -1,13 +1,16 @@
 import { ITEM_BY_TRANSLATED } from '@/assets/data'
 
 export function magicBasetype (name: string) {
-  const words = name.split(' ')
+  // Chinese/Korean names have no spaces to split on, so fall back to characters
+  const hasSpaces = name.includes(' ')
+  const words = hasSpaces ? name.split(' ') : [...name]
+  const separator = hasSpaces ? ' ' : ''
 
   const perm: string[] = words.flatMap((_, start) =>
     Array(words.length - start).fill(undefined)
       .map((_, idx) => words
         .slice(start, start + idx + 1)
-        .join(' ')
+        .join(separator)
       )
   )
 


### PR DESCRIPTION
## Problem

Price-checking a **magic item** in a language whose item names contain no spaces (Chinese, Korean) fails with **"Unknown Item"**, even though the item's base type exists in the game data.
Example (Traditional Chinese, `cmn-Hant`) — a magic Medium Cluster Jewel:

物品種類: 珠寶
稀有度: 魔法
顯著的中型星團珠寶


The base type `中型星團珠寶` (Medium Cluster Jewel) is present in `data/cmn-Hant/items.ndjson` and is marked `craftable`, but parsing still returns `item.unknown`.
<img width="458" height="573" alt="image" src="https://github.com/user-attachments/assets/9a4d14e2-69c2-4e0a-a826-c96bcba776bb" />

## Root cause

Magic items don't expose their base type on a separate clipboard line the way rare/normal items do — the base is embedded in a single string together with the prefix and suffix (`前綴 + 基底 + 後綴`). To recover the base, `normalizeName()` calls `magicBasetype()`, which builds every contiguous substring of the name and looks each one up in the item database.

For English (Enameled Medium Cluster Jewel of Clouds) this yields the words and their combinations, so Medium Cluster Jewel is found. For Chinese/Korean the name has no spaces, so split(' ') returns the whole string as a single element. The only candidate looked up is the full affixed name, which never matches a base type, so findInDatabase() falls through to item.unknown.

Rare/normal items are unaffected because their base type is parsed directly from
its own clipboard line and never goes through magicBasetype().

Testing
- Chinese magic Cluster Jewel (顯著的中型星團珠寶): now correctly resolves the base to 中型星團珠寶 and price-checks successfully.
- English magic items: unchanged — still split on spaces and resolve as before.

