### PR TITLE
Fix DEVELOPING.md to match CI and lockfiles

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -13,31 +13,32 @@ The most up-to-date instructions can always be derived from CI:
 
 [.github/workflows/main.yml](https://github.com/SnosMe/awakened-poe-trade/blob/master/.github/workflows/main.yml)
 
-Here's what that looks like as of 2023-12-03.
+Here's what that looks like as of 2026-08-01.
 
 ```shell
 cd renderer
-yarn install
-yarn make-index-files
-yarn dev
+npm ci
+npm run make-index-files
+npm run dev
 
 # In a second shell
 cd main
-yarn install
-yarn dev
+npm ci
+npm run dev
 ```
 
 # How to build
 
 ```shell
 cd renderer
-yarn install
-yarn make-index-files
-yarn build
+npm ci
+npm run make-index-files
+npm run build
 
 cd ../main
-yarn build
+npm ci
+npm run build
 # We want to sign with a distribution certificate to ensure other users can
 # install without errors
-CSC_NAME="Certificate name in Keychain" yarn package
+CSC_NAME="Certificate name in Keychain" npm run package
 ```


### PR DESCRIPTION
The repo tracks main/package-lock.json and renderer/package-lock.json, and .github/workflows/main.yml installs with `npm ci`, but DEVELOPING.md still documented yarn.

Updated it to reference the correct steps.