### PR TITLE
Add "Smart Round" feature to price check

### DIFF
--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -342,6 +342,7 @@
     "show_seller": "Show seller",
     "fill_rolls": "Fill stat values",
     "fill_roll_exact": "Exact value",
+    "fill_roll_round": "Smart Rounding",
     "cursor_pos": "Show memorized cursor position",
     "extra_delay": "Extra time to prevent spurious Rate limiting",
     "warn_expensive": "Settings below are a compromise between increasing load on PoE website and convenient price checking / more accurate search.",

--- a/renderer/src/web/price-check/filters/create-stat-filters.ts
+++ b/renderer/src/web/price-check/filters/create-stat-filters.ts
@@ -1,6 +1,6 @@
 import { ParsedItem, ItemRarity, ItemCategory } from '@/parser'
 import { ModifierType, StatCalculated, statSourcesTotal, translateStatWithRoll } from '@/parser/modifiers'
-import { percentRoll, percentRollDelta, roundRoll } from './util'
+import { percentRoll, percentRollDelta, roundRoll, roundedRoll, STAT_RANGE_ROUND } from './util'
 import { FilterTag, ItemHasEmptyModifier, StatFilter } from './interfaces'
 import { filterPseudo } from './pseudo'
 import { applyRules as applyAtzoatlRules } from './pseudo/atzoatl-rules'
@@ -320,17 +320,25 @@ export function calculatedStatToFilter (
       max: percentRoll(roll.max, +0, Math.ceil, dp)
     }
 
-    const filterDefault = (calc.stat.better === StatBetter.NotComparable)
-      ? { min: roll.value, max: roll.value }
-      : (item.rarity === ItemRarity.Unique)
-          ? {
-              min: percentRollDelta(roll.value, (roll.max - roll.min), -percent, Math.floor, dp),
-              max: percentRollDelta(roll.value, (roll.max - roll.min), +percent, Math.ceil, dp)
-            }
-          : {
-              min: percentRoll(roll.value, -percent, Math.floor, dp),
-              max: percentRoll(roll.value, +percent, Math.ceil, dp)
-            }
+    let filterDefault: { min: number, max: number }
+    if (calc.stat.better === StatBetter.NotComparable) {
+      filterDefault = { min: roll.value, max: roll.value }
+    } else if (percent === STAT_RANGE_ROUND) {
+      filterDefault = {
+        min: roundedRoll(roll.value, Math.floor, dp),
+        max: roundedRoll(roll.value, Math.ceil, dp)
+      }
+    } else if (item.rarity === ItemRarity.Unique) {
+      filterDefault = {
+        min: percentRollDelta(roll.value, (roll.max - roll.min), -percent, Math.floor, dp),
+        max: percentRollDelta(roll.value, (roll.max - roll.min), +percent, Math.ceil, dp)
+      }
+    } else {
+      filterDefault = {
+        min: percentRoll(roll.value, -percent, Math.floor, dp),
+        max: percentRoll(roll.value, +percent, Math.ceil, dp)
+      }
+    }
     filterDefault.min = Math.max(filterDefault.min, filterBounds.min)
     filterDefault.max = Math.min(filterDefault.max, filterBounds.max)
 

--- a/renderer/src/web/price-check/filters/create-stat-filters.ts
+++ b/renderer/src/web/price-check/filters/create-stat-filters.ts
@@ -321,13 +321,35 @@ export function calculatedStatToFilter (
     }
 
     let filterDefault: { min: number, max: number }
+    let clampToBounds = true
     if (calc.stat.better === StatBetter.NotComparable) {
       filterDefault = { min: roll.value, max: roll.value }
     } else if (percent === STAT_RANGE_ROUND) {
-      filterDefault = {
+      const rounded = {
         min: roundedRoll(roll.value, Math.floor, dp),
         max: roundedRoll(roll.value, Math.ceil, dp)
       }
+      // A mod with a narrow range (jewel life only rolls 5-7%) can round clean
+      // past its own bounds, leaving a filter that every roll of the mod
+      // passes. Those are worth more pinned to the exact value.
+      //
+      // The bounds of a pseudo total only describe this item's own sources;
+      // other items reach the same total from different combinations, so the
+      // filter still discriminates and rounding stands.
+      const matchesWholeRange = type !== ModifierType.Pseudo && (
+        (calc.stat.better === StatBetter.PositiveRoll && rounded.min <= roll.min) ||
+        (calc.stat.better === StatBetter.NegativeRoll && rounded.max >= roll.max))
+      filterDefault = (matchesWholeRange)
+        ? {
+            min: percentRoll(roll.value, -0, Math.floor, dp),
+            max: percentRoll(roll.value, +0, Math.ceil, dp)
+          }
+        : rounded
+      // hitting the breakpoint is the point of the mode, and clamping back to
+      // the item's own roll range would undo it. A rounded bound below that
+      // range only reaches this far on a pseudo total, where other items get
+      // to the same total by other means.
+      clampToBounds = matchesWholeRange
     } else if (item.rarity === ItemRarity.Unique) {
       filterDefault = {
         min: percentRollDelta(roll.value, (roll.max - roll.min), -percent, Math.floor, dp),
@@ -339,8 +361,10 @@ export function calculatedStatToFilter (
         max: percentRoll(roll.value, +percent, Math.ceil, dp)
       }
     }
-    filterDefault.min = Math.max(filterDefault.min, filterBounds.min)
-    filterDefault.max = Math.min(filterDefault.max, filterBounds.max)
+    if (clampToBounds) {
+      filterDefault.min = Math.max(filterDefault.min, filterBounds.min)
+      filterDefault.max = Math.min(filterDefault.max, filterBounds.max)
+    }
 
     filter.roll = {
       value: roundRoll(roll.value, dp),

--- a/renderer/src/web/price-check/filters/util.ts
+++ b/renderer/src/web/price-check/filters/util.ts
@@ -13,6 +13,44 @@ export function roundRoll (value: number, dp: boolean) {
   return Math.trunc(value * rounding) / rounding
 }
 
+// Sentinel for `searchStatRange`, alongside `0` meaning "exact value".
+// Negative so it can never collide with a real percentage.
+export const STAT_RANGE_ROUND = -1
+
+// Smallest power of ten that turns the value into a whole number.
+function wholeNumberScale (value: number): number {
+  for (const scale of [1, 10, 100]) {
+    if (Math.abs(value * scale - Math.round(value * scale)) < 1e-9) return scale
+  }
+  return 1000
+}
+
+// Snaps to a "round" value a buyer would actually type into trade: multiples
+// of 5 below 50, multiples of 10 at or above it. Widens outward like
+// `percentRoll` does — `Math.floor` for the min side, `Math.ceil` for the max
+// side — so the item always falls inside its own filter (42 -> 40+).
+export function roundedRoll (
+  value: number,
+  method: Math['floor'] | Math['ceil'],
+  dp: boolean
+): number {
+  // Fractional stats scale up to a whole number so they use the same
+  // breakpoints as everything else: 6.4 goes 64 -> 60 -> 6.0, and 2.95 goes
+  // 295 -> 290 -> 2.9.
+  const scale = (dp) ? wholeNumberScale(value) : 1
+  const scaled = Math.round(value * scale)
+
+  // Single digits once scaled (+3 to level of gems, 0.9 attacks per second)
+  // have no useful breakpoint between them, so leave them alone. This also
+  // keeps small rolls off 0, which would drop the constraint entirely.
+  if (Math.abs(scaled) < 10) {
+    return roundRoll(value, dp)
+  }
+
+  const step = (Math.abs(scaled) < 50) ? 5 : 10
+  return (method(scaled / step) * step) / scale
+}
+
 export function percentRoll (
   value: number,
   p: number,

--- a/renderer/src/web/price-check/settings-price-check.vue
+++ b/renderer/src/web/price-check/settings-price-check.vue
@@ -44,10 +44,11 @@
       <div class="mb-4 flex">
         <div class="flex mr-6">
           <span class="mr-1">+-</span>
-          <input v-model.number="searchStatRange" class="rounded bg-gray-900 px-1 block w-16 mb-1 font-poe text-center" />
+          <input v-model.number="searchStatRangePercent" class="rounded bg-gray-900 px-1 block w-16 mb-1 font-poe text-center" />
           <span class="ml-1">%</span>
         </div>
-        <ui-radio v-model="searchStatRange" :value="0">{{ t(':fill_roll_exact') }}</ui-radio>
+        <ui-radio v-model="searchStatRange" :value="0" class="mr-4">{{ t(':fill_roll_exact') }}</ui-radio>
+        <ui-radio v-model="searchStatRange" :value="STAT_RANGE_ROUND">{{ t(':fill_roll_round') }}</ui-radio>
       </div>
     </div>
     <!-- <ui-checkbox class="mb-4"
@@ -100,6 +101,7 @@ import UiCheckbox from '@/web/ui/UiCheckbox.vue'
 import UiToggle from '@/web/ui/UiToggle.vue'
 import UiErrorBox from '@/web/ui/UiErrorBox.vue'
 import { configModelValue, configProp, findWidget } from '../settings/utils.js'
+import { STAT_RANGE_ROUND } from './filters/util'
 import type { PriceCheckWidget } from '@/web/overlay/interfaces'
 import { useLeagues } from '../background/Leagues'
 
@@ -136,9 +138,24 @@ export default defineComponent({
       smartInitialSearch: configModelValue(() => configWidget.value, 'smartInitialSearch'),
       lockedInitialSearch: configModelValue(() => configWidget.value, 'lockedInitialSearch'),
       rememberCurrency: configModelValue(() => configWidget.value, 'rememberCurrency'),
+      STAT_RANGE_ROUND,
       searchStatRange: computed<number>({
         get () {
           return configWidget.value.searchStatRange
+        },
+        set (value) {
+          if (typeof value !== 'number') return
+
+          if (value === STAT_RANGE_ROUND || (value >= 0 && value <= 50)) {
+            configWidget.value.searchStatRange = value
+          }
+        }
+      }),
+      // Blank rather than showing the sentinel as "-1 %" in the percent box.
+      searchStatRangePercent: computed<number | string>({
+        get () {
+          const value = configWidget.value.searchStatRange
+          return (value === STAT_RANGE_ROUND) ? '' : value
         },
         set (value) {
           if (typeof value !== 'number') return


### PR DESCRIPTION
Add an optional mode for the value ranges. In "Smart Round" mode it will round values down to the nearest "round" number. This matches how humans often search for things. For example, a value of 83 would end up searching for >= 80. A value of 2.95 would end up searching for >= 2.9. Small values are ignored. For example a value of `4` falls back to the previous behavior (it wouldn't really make sense to round it to 0). For values with a small range, we also force the max to stay that way. For example, 5-7% increased max life would result in a 7% roll remaining the 7% when searching.

We could make it better later by having it check for the value within the mod tier instead.