### PR TITLE
Make the default-enabled mods configurable

### DIFF
--- a/renderer/public/data/en/app_i18n.json
+++ b/renderer/public/data/en/app_i18n.json
@@ -197,7 +197,9 @@
     "tag_explicit_veiled": "Veiled",
     "tag_explicit_incursion": "Incursion",
     "tag_explicit_infamous": "Mercenary",
-    "tag_explicit_essence": "Essence"
+    "tag_explicit_essence": "Essence",
+    "pin_default": "Always enable this mod by default",
+    "unpin_default": "Stop enabling this mod by default"
   },
   "online_filter": {
     "offline_toggle": "Offline & Online",
@@ -341,6 +343,9 @@
     "show_seller": "Show seller",
     "fill_rolls": "Fill stat values",
     "fill_roll_exact": "Exact value",
+    "default_enabled": "Enabled by default",
+    "default_enabled_hint": "Pin a mod from the price check panel to always tick it.",
+    "default_enabled_empty": "Nothing pinned yet.",
     "cursor_pos": "Show memorized cursor position",
     "extra_delay": "Extra time to prevent spurious Rate limiting",
     "warn_expensive": "Settings below are a compromise between increasing load on PoE website and convenient price checking / more accurate search.",

--- a/renderer/src/web/Config.ts
+++ b/renderer/src/web/Config.ts
@@ -3,6 +3,7 @@ import isDeepEqual from 'fast-deep-equal'
 import { Host } from '@/web/background/IPC'
 import { HostConfig, ShortcutAction } from '@ipc/types'
 import type * as widget from './overlay/widgets'
+import { DEFAULT_ENABLED_STATS } from './overlay/widgets'
 import type { StashSearchWidget } from './stash-search/widget'
 import type { ItemCheckWidget } from './item-check/widget'
 import type { ItemSearchWidget } from './item-search/widget'
@@ -123,7 +124,7 @@ export interface Config {
 }
 
 export const defaultConfig = (): Config => ({
-  configVersion: 18,
+  configVersion: 19,
   overlayKey: 'Shift + Space',
   overlayBackground: 'rgba(129, 139, 149, 0.15)',
   overlayBackgroundClose: true,
@@ -431,6 +432,13 @@ function upgradeConfig (_config: Config): Config {
     config.useIntlSite = (config.language === 'cmn-Hant' && config.realm === 'pc-ggg')
 
     config.configVersion = 18
+  }
+
+  if (config.configVersion < 19) {
+    config.widgets.find(w => w.wmType === 'price-check')!
+      .defaultEnabledStats = [...DEFAULT_ENABLED_STATS]
+
+    config.configVersion = 19
   }
   /* eslint-enable */
 

--- a/renderer/src/web/overlay/widgets.ts
+++ b/renderer/src/web/overlay/widgets.ts
@@ -1,3 +1,12 @@
+// Stat refs ticked automatically on every price check. Seeded with the set
+// that used to be hardcoded in PSEUDO_RULES; users pin and unpin the rest
+// from the price check panel.
+export const DEFAULT_ENABLED_STATS = [
+  '+#% total Elemental Resistance',
+  '+# total maximum Life',
+  '+#% total to Chaos Resistance'
+]
+
 export interface Widget {
   wmId: number
   wmType: string
@@ -41,6 +50,7 @@ export interface PriceCheckWidget extends Widget {
   hotkeyLocked: string | null
   showSeller: false | 'account' | 'ign'
   searchStatRange: number
+  defaultEnabledStats: string[]
   showRateLimitState: boolean
   apiLatencySeconds: number
   collapseListings: 'api' | 'app'

--- a/renderer/src/web/price-check/CheckedItem.vue
+++ b/renderer/src/web/price-check/CheckedItem.vue
@@ -114,6 +114,7 @@ export default defineComponent({
         collapseListings: widget.value.collapseListings,
         activateStockFilter: widget.value.activateStockFilter,
         searchStatRange: widget.value.searchStatRange,
+        defaultEnabledStats: widget.value.defaultEnabledStats,
         useEn: AppConfig().useIntlSite,
         currency: (prevItem &&
           item.info.namespace === prevItem.info.namespace &&

--- a/renderer/src/web/price-check/PriceCheckWindow.vue
+++ b/renderer/src/web/price-check/PriceCheckWindow.vue
@@ -86,6 +86,7 @@ import CheckPositionCircle from './CheckPositionCircle.vue'
 import AppTitleBar from '@/web/ui/AppTitlebar.vue'
 import ItemQuickPrice from '@/web/ui/ItemQuickPrice.vue'
 import { PriceCheckWidget, WidgetManager, WidgetSpec } from '../overlay/interfaces'
+import { DEFAULT_ENABLED_STATS } from '../overlay/widgets'
 
 type ParseError = { name: string; message: string; rawText: ParsedItem['rawText'] }
 
@@ -113,6 +114,7 @@ export default defineComponent({
         hotkeyLocked: 'Ctrl + Alt + D',
         showSeller: false,
         searchStatRange: 10,
+        defaultEnabledStats: [...DEFAULT_ENABLED_STATS],
         showCursor: true,
         requestPricePrediction: false,
         rememberCurrency: false

--- a/renderer/src/web/price-check/filters/FilterModifier.vue
+++ b/renderer/src/web/price-check/filters/FilterModifier.vue
@@ -18,6 +18,11 @@
           </div>
         </button>
         <div class="flex items-baseline gap-x-1">
+          <button v-if="canPin" type="button" @click="togglePinned"
+            :class="[$style['pin'], { [$style['pin-active']]: isPinned }]"
+            :title="isPinned ? t('filters.unpin_default') : t('filters.pin_default')">
+            <i class="fas fa-thumbtack"></i>
+          </button>
           <div v-if="showQ20Notice" :class="$style['qualityLabel']">{{ t('item.prop_quality', [calcQuality]) }}</div>
           <div class="flex gap-x-px">
             <input :class="$style['rollInput']" :placeholder="t('min')" :min="roll?.bounds?.min" :max="roll?.bounds?.max" :step="changeStep" type="number"
@@ -78,6 +83,7 @@ import FilterModifierTiers from './FilterModifierTiers.vue'
 import { AppConfig } from '@/web/Config'
 import { ItemCategory, ItemRarity, ParsedItem } from '@/parser'
 import { FilterTag, StatFilter, INTERNAL_TRADE_IDS } from './interfaces'
+import type { PriceCheckWidget } from '@/web/overlay/widgets'
 import SourceInfo from './SourceInfo.vue'
 
 export default defineComponent({
@@ -219,13 +225,44 @@ export default defineComponent({
           )
         )),
       inputFocus,
-      toggleFilter
+      toggleFilter,
+      canPin: computed(() =>
+        !INTERNAL_TRADE_IDS.includes(props.filter.tradeId[0]) &&
+        props.filter.tag !== FilterTag.Property),
+      isPinned: computed(() =>
+        pinnedStats().includes(props.filter.statRef)),
+      togglePinned () {
+        const pinned = pinnedStats()
+        const at = pinned.indexOf(props.filter.statRef)
+        if (at === -1) {
+          pinned.push(props.filter.statRef)
+          props.filter.disabled = false
+        } else {
+          pinned.splice(at, 1)
+        }
+      }
     }
   }
 })
+
+function pinnedStats (): string[] {
+  return AppConfig<PriceCheckWidget>('price-check')!.defaultEnabledStats
+}
 </script>
 
 <style lang="postcss" module>
+.pin {
+  @apply text-xs leading-none;
+  @apply text-gray-700;
+  @apply px-1;
+}
+.pin:hover {
+  @apply text-gray-400;
+}
+.pin-active {
+  @apply text-gray-400;
+}
+
 .filter {
   @apply py-2;
   @apply border-b border-gray-700;

--- a/renderer/src/web/price-check/filters/create-presets.ts
+++ b/renderer/src/web/price-check/filters/create-presets.ts
@@ -14,6 +14,7 @@ export function createPresets (
     collapseListings: 'app' | 'api'
     activateStockFilter: boolean
     searchStatRange: number
+    defaultEnabledStats: string[]
     useEn: boolean
   }
 ): { presets: FilterPreset[], active: string } {

--- a/renderer/src/web/price-check/filters/create-stat-filters.ts
+++ b/renderer/src/web/price-check/filters/create-stat-filters.ts
@@ -15,6 +15,7 @@ import { StatBetter, CLIENT_STRINGS } from '@/assets/data'
 export interface FiltersCreationContext {
   readonly item: ParsedItem
   readonly searchInRange: number
+  readonly defaultEnabledStats: string[]
   filters: StatFilter[]
   statsByType: StatCalculated[]
 }
@@ -22,7 +23,7 @@ export interface FiltersCreationContext {
 export function createExactStatFilters (
   item: ParsedItem,
   statsByType: StatCalculated[],
-  opts: { searchStatRange: number }
+  opts: { searchStatRange: number, defaultEnabledStats: string[] }
 ): StatFilter[] {
   if (
     item.mapBlighted ||
@@ -63,6 +64,7 @@ export function createExactStatFilters (
 
   const ctx: FiltersCreationContext = {
     item,
+    defaultEnabledStats: opts.defaultEnabledStats,
     searchInRange: (item.category !== ItemCategory.Map)
       ? Math.min(2, opts.searchStatRange)
       : opts.searchStatRange,
@@ -142,11 +144,13 @@ export function initUiModFilters (
   item: ParsedItem,
   opts: {
     searchStatRange: number
+    defaultEnabledStats: string[]
   }
 ): StatFilter[] {
   const ctx: FiltersCreationContext = {
     item,
     filters: [],
+    defaultEnabledStats: opts.defaultEnabledStats,
     searchInRange: (item.rarity === ItemRarity.Normal) ? 100 : opts.searchStatRange,
     statsByType: item.statsByType.map(calc => {
       if (calc.type === ModifierType.Fractured && calc.stat.trade.ids[ModifierType.Explicit]) {
@@ -463,6 +467,12 @@ function finalFilterTweaks (ctx: FiltersCreationContext) {
         filter.hidden = 'filters.hide_for_crafting'
       }
     } else if (filter.tag === FilterTag.Foulborn || filter.tag === FilterTag.Variant) {
+      filter.disabled = false
+    }
+  }
+
+  for (const filter of ctx.filters) {
+    if (!filter.hidden && ctx.defaultEnabledStats.includes(filter.statRef)) {
       filter.disabled = false
     }
   }

--- a/renderer/src/web/price-check/filters/pseudo/index.ts
+++ b/renderer/src/web/price-check/filters/pseudo/index.ts
@@ -44,7 +44,6 @@ interface PseudoRule {
 const PSEUDO_RULES: PseudoRule[] = [
   {
     pseudo: stat('+#% total Elemental Resistance'),
-    disabled: false,
     stats:
       RESISTANCES_INFO.filter(info => info.elements.length)
         .map(info => ({ ref: info.ref, multiplier: info.elements.length }))
@@ -80,8 +79,6 @@ const PSEUDO_RULES: PseudoRule[] = [
           filter.sources[0].modifier.info.type === ModifierType.Crafted
       ) {
         filter.hidden = 'filters.hide_crafted_chaos'
-      } else {
-        filter.disabled = false
       }
     }
   },
@@ -116,7 +113,6 @@ const PSEUDO_RULES: PseudoRule[] = [
   },
   {
     pseudo: stat('+# total maximum Life'),
-    disabled: false,
     stats: [
       { ref: stat('+# to maximum Life'), required: true },
       ...ATTRIBUTES_INFO.filter(info => info.attributes.includes('str'))

--- a/renderer/src/web/price-check/settings-price-check.vue
+++ b/renderer/src/web/price-check/settings-price-check.vue
@@ -50,6 +50,17 @@
         <ui-radio v-model="searchStatRange" :value="0">{{ t(':fill_roll_exact') }}</ui-radio>
       </div>
     </div>
+    <div class="mb-4">
+      <div class="flex-1 mb-1">{{ t(':default_enabled') }}</div>
+      <div class="mb-1 italic text-gray-500">{{ t(':default_enabled_hint') }}</div>
+      <div v-if="!defaultEnabledStats.length" class="text-gray-500">{{ t(':default_enabled_empty') }}</div>
+      <div v-for="statRef of defaultEnabledStats" :key="statRef"
+        class="flex items-baseline gap-x-2 mb-px">
+        <button type="button" class="text-gray-500 hover:text-red-400"
+          @click="removeDefaultStat(statRef)"><i class="fas fa-times"></i></button>
+        <span class="font-poe truncate">{{ statRef }}</span>
+      </div>
+    </div>
     <!-- <ui-checkbox class="mb-4"
       v-model="rememberCurrency">{{ t(':remember_currency') }}</ui-checkbox> -->
     <ui-checkbox class="mb-4"
@@ -136,6 +147,12 @@ export default defineComponent({
       smartInitialSearch: configModelValue(() => configWidget.value, 'smartInitialSearch'),
       lockedInitialSearch: configModelValue(() => configWidget.value, 'lockedInitialSearch'),
       rememberCurrency: configModelValue(() => configWidget.value, 'rememberCurrency'),
+      defaultEnabledStats: computed(() => configWidget.value.defaultEnabledStats),
+      removeDefaultStat (statRef: string) {
+        const pinned = configWidget.value.defaultEnabledStats
+        const at = pinned.indexOf(statRef)
+        if (at !== -1) pinned.splice(at, 1)
+      },
       searchStatRange: computed<number>({
         get () {
           return configWidget.value.searchStatRange


### PR DESCRIPTION
Which mods start ticked was hardcoded: three PSEUDO_RULES carried
`disabled: false` and nothing else could be added without editing source.

Moves that set into config as `defaultEnabledStats`, seeded with the same three (total elemental resistance, total maximum life, chaos resistance) so behaviour is unchanged after migration. A pin button on each row of the price check panel adds or removes the mod, and the settings page lists what is pinned with remove buttons.

Because the list is now the only thing enabling those stats, the seeded three can be unpinned too, which was not possible before.