### PR TITLE
Show map property filters on all Originator maps

### DIFF
--- a/renderer/src/web/price-check/filters/pseudo/maps.ts
+++ b/renderer/src/web/price-check/filters/pseudo/maps.ts
@@ -17,13 +17,20 @@ const VALDO_LETHAL_STATS = [
   stat('Players who Die in area are sent to the Void')
 ]
 
+const ORIGINATOR_IMPLICIT = stat("Area is Influenced by the Originator's Memories")
+
 export function mapProps (ctx: FiltersCreationContext): void {
   const { item } = ctx
   if (!item.map || item.mapBlighted || item.mapCompletionReward || item.rarity === ItemRarity.Unique) return
 
   const hasMoreDrops = Boolean(item.map.moreMaps || item.map.moreScarabs || item.map.moreCurrency || item.map.moreDivCards)
 
-  if (!item.isCorrupted && !hasMoreDrops && item.info.refName !== 'Nightmare Map') return
+  // Originator maps are priced on quantity/rarity/pack size whether or not
+  // they rolled any of the "More ..." drop properties.
+  const isOriginator = item.statsByType.some(calc =>
+    calc.type === ModifierType.Implicit && calc.stat.ref === ORIGINATOR_IMPLICIT)
+
+  if (!item.isCorrupted && !hasMoreDrops && !isOriginator && item.info.refName !== 'Nightmare Map') return
 
   if (item.map.itemQuantity) {
     ctx.filters.push(propToFilter({


### PR DESCRIPTION
Quantity, rarity and pack size were only offered when a map was corrupted, had rolled one of the "More ..." drop properties, or was a Nightmare Map. An Originator map without any "More ..." property fell through all three and got no property filters at all, even though those three stats are what it is priced on.

Verified against both maps: the one with More Maps/More Currency is unchanged, the one without goes from 0 filters to 3.

 Closes #1893