### PR TITLE
Offer the empty affix filter on flasks

### DIFF
--- a/renderer/src/web/price-check/filters/create-stat-filters.ts
+++ b/renderer/src/web/price-check/filters/create-stat-filters.ts
@@ -125,6 +125,8 @@ export function createExactStatFilters (
   } else if (item.category === ItemCategory.Flask) {
     applyFlaskRules(ctx.filters)
     applyFlaskHybridMod(ctx)
+    // flasks use this preset, which never reaches finalFilterTweaks
+    pushHasEmptyModifier(ctx)
   } else if (
     item.category === ItemCategory.MemoryLine ||
     item.category === ItemCategory.SanctumRelic ||
@@ -437,21 +439,7 @@ function finalFilterTweaks (ctx: FiltersCreationContext) {
     applyFlaskHybridMod(ctx)
   }
 
-  const hasEmptyModifier = showHasEmptyModifier(ctx)
-  if (hasEmptyModifier !== false) {
-    ctx.filters.push({
-      tradeId: ['item.has_empty_modifier'],
-      text: '1 Empty or Crafted Modifier',
-      statRef: '1 Empty or Crafted Modifier',
-      disabled: true,
-      hidden: 'filters.hide_empty_mod',
-      tag: FilterTag.Pseudo,
-      sources: [],
-      option: {
-        value: hasEmptyModifier
-      }
-    })
-  }
+  pushHasEmptyModifier(ctx)
 
   if (item.category === ItemCategory.Amulet || item.category === ItemCategory.Ring) {
     applyAnointmentRules(ctx.filters, ctx.item)
@@ -527,14 +515,44 @@ function applyFlaskRules (filters: StatFilter[]) {
 // TODO
 // +1 Prefix Modifier allowed
 // -1 Suffix Modifier allowed
+function pushHasEmptyModifier (ctx: FiltersCreationContext) {
+  const hasEmptyModifier = showHasEmptyModifier(ctx)
+  if (hasEmptyModifier === false) return
+
+  ctx.filters.push({
+    tradeId: ['item.has_empty_modifier'],
+    text: '1 Empty or Crafted Modifier',
+    statRef: '1 Empty or Crafted Modifier',
+    disabled: true,
+    // with only two slots to fill, the open one is much of what a magic item
+    // sells on, so show it rather than tucking it behind the hidden toggle
+    hidden: (ctx.item.rarity === ItemRarity.Magic)
+      ? undefined
+      : 'filters.hide_empty_mod',
+    tag: FilterTag.Pseudo,
+    sources: [],
+    option: {
+      value: hasEmptyModifier
+    }
+  })
+}
+
+// How many prefixes and suffixes the item can hold at all. A magic item holds
+// one of each, which is what a flask or a magic jewel gets; only a rare has the
+// 3+3 the counting below used to assume.
+function affixCapacity (item: ParsedItem): { prefixes: number, suffixes: number } | null {
+  if (item.isCorrupted || item.isMirrored) return null
+
+  if (item.rarity === ItemRarity.Magic) return { prefixes: 1, suffixes: 1 }
+  if (item.rarity === ItemRarity.Rare) return { prefixes: 3, suffixes: 3 }
+  return null
+}
+
 function showHasEmptyModifier (ctx: FiltersCreationContext): ItemHasEmptyModifier | false {
   const { item } = ctx
 
-  if (
-    item.rarity !== ItemRarity.Rare ||
-    item.isCorrupted ||
-    item.isMirrored
-  ) return false
+  const capacity = affixCapacity(item)
+  if (!capacity) return false
 
   const randomMods = item.newMods.filter(mod =>
     mod.info.type === ModifierType.Explicit ||
@@ -543,10 +561,11 @@ function showHasEmptyModifier (ctx: FiltersCreationContext): ItemHasEmptyModifie
     mod.info.type === ModifierType.Crafted)
 
   const craftedMod = randomMods.find(mod => mod.info.type === ModifierType.Crafted)
+  const total = capacity.prefixes + capacity.suffixes
 
   if (
-    (randomMods.length === 5 && !craftedMod) ||
-    (randomMods.length === 6 && craftedMod)
+    (randomMods.length === total - 1 && !craftedMod) ||
+    (randomMods.length === total && craftedMod)
   ) {
     let prefixes = randomMods.filter(mod => mod.info.generation === 'prefix').length
     let suffixes = randomMods.filter(mod => mod.info.generation === 'suffix').length
@@ -559,8 +578,8 @@ function showHasEmptyModifier (ctx: FiltersCreationContext): ItemHasEmptyModifie
       }
     }
 
-    if (prefixes === 2) return ItemHasEmptyModifier.Prefix
-    if (suffixes === 2) return ItemHasEmptyModifier.Suffix
+    if (prefixes === capacity.prefixes - 1) return ItemHasEmptyModifier.Prefix
+    if (suffixes === capacity.suffixes - 1) return ItemHasEmptyModifier.Suffix
   }
 
   return false


### PR DESCRIPTION
Closes #1898.

A flask with an open suffix is worth more than a full one, since the suffix can still be crafted at the bench, but the filter was gated on rare items with 3+3 affix slots. Flasks are never rare and hold one prefix and one suffix, so they failed the first check.

Affix capacity is now per item type and the existing counting works off it, so rare items behave exactly as before. Flasks also take the exact preset, which never reaches finalFilterTweaks, so the filter is pushed from there too.

Shown rather than hidden for flasks, since an open suffix is much of what the flask sells on, unlike the rare case where it is a footnote.