### PR TITLE
Offer only the affix slots that apply to the item

### DIFF
--- a/renderer/src/web/price-check/filters/FilterModifier.vue
+++ b/renderer/src/web/price-check/filters/FilterModifier.vue
@@ -48,7 +48,7 @@
           <span v-if="showTag"
             :class="[$style['tag'], $style[`tag-${tag}`]]">{{ t(`filters.tag_${tag.replace('-', '_')}`) }}{{ (filter.sources.length > 1) ? ` x ${filter.sources.length}` : null }}</span>
           <filter-modifier-tiers :filter="filter" :item="item" />
-          <filter-modifier-item-has-empty :filter="filter" />
+          <filter-modifier-item-has-empty :filter="filter" :item="item" />
         </div>
         <stat-roll-slider v-if="roll && roll.bounds"
           class="ml-2 mr-4" style="width: 12.5rem;"

--- a/renderer/src/web/price-check/filters/FilterModifierItemHasEmpty.vue
+++ b/renderer/src/web/price-check/filters/FilterModifierItemHasEmpty.vue
@@ -9,12 +9,17 @@
 <script lang="ts">
 import { defineComponent, PropType, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
+import { ItemRarity, ParsedItem } from '@/parser'
 import { StatFilter, ItemHasEmptyModifier } from './interfaces'
 
 export default defineComponent({
   props: {
     filter: {
       type: Object as PropType<StatFilter>,
+      required: true
+    },
+    item: {
+      type: Object as PropType<ParsedItem>,
       required: true
     }
   },
@@ -33,11 +38,17 @@ export default defineComponent({
         [ItemHasEmptyModifier.Any, 'item.has_empty_affix'],
         [ItemHasEmptyModifier.Prefix, 'item.has_empty_prefix'],
         [ItemHasEmptyModifier.Suffix, 'item.has_empty_suffix']
-      ] as const).map(([value, text]) => ({
-        text,
-        select: () => select(value),
-        isSelected: (filter.option!.value === value)
-      }))
+      ] as const)
+        .filter(([value]) => {
+          if (value === filter.option!.value) return true
+          return value === ItemHasEmptyModifier.Any &&
+            props.item.rarity === ItemRarity.Rare
+        })
+        .map(([value, text]) => ({
+          text,
+          select: () => select(value),
+          isSelected: (filter.option!.value === value)
+        }))
     })
 
     const { t } = useI18n()


### PR DESCRIPTION
The empty-modifier filter rendered Any/Prefix/Suffix on every item, but detection only ever reports Prefix or Suffix. Selecting the opposite one searches for items unlike the one being checked, so it is never the right answer.

"Any" is kept where widening is worth it. A rare holds six affixes, so falling back to any of them is useful when the named-slot search is too thin. Item types that hold one prefix and one suffix get only the matching slot, since "any" would say little more.